### PR TITLE
#72 refresh devices on tray creation

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -155,11 +155,6 @@ function setDevicesCycleColors(colors) {
 
 let mainMenu = [
   {
-    label: 'Refresh Device List',
-    click() { refreshDevices(); refreshTray(); },
-  },
-  { type: 'separator' },
-  {
     label: 'Spectrum All Devices',
     click() {
       // manually use an interval so that all devices are gauranteed in sync.
@@ -694,6 +689,7 @@ app.on('quit', () => {
 })
 
 nativeTheme.on('updated', () => {
+ refreshDevices();
  createTray();
 })
 


### PR DESCRIPTION
In order to show updated battery level on devices, the device list should be refreshed each time the menu is opened.