### PR TITLE
Add keyboard brightness support

### DIFF
--- a/src/driver/addon.cc
+++ b/src/driver/addon.cc
@@ -169,6 +169,21 @@ void KbdSetModeBreathe(const Napi::CallbackInfo &info)
   razer_attr_write_mode_breath(kbdDev, buf, 1);
 }
 
+Napi::Number KbdGetBrightness(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  // Return -1 if no device
+  if (kbdDev == NULL)
+  {
+    return Napi::Number::New(env, -1);
+  }
+
+  ushort brightness = razer_attr_read_set_brightness(kbdDev);
+
+  return Napi::Number::New(env, brightness);
+}
+
 void KbdSetBrightness(const Napi::CallbackInfo &info)
 {
   if (kbdDev == NULL)
@@ -910,6 +925,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("kbdSetModeWave", Napi::Function::New(env, KbdSetModeWave));
   exports.Set("kbdSetModeReactive", Napi::Function::New(env, KbdSetModeReactive));
   exports.Set("kbdSetModeBreathe", Napi::Function::New(env, KbdSetModeBreathe));
+  exports.Set("KbdGetBrightness", Napi::Function::New(env, KbdGetBrightness));
   exports.Set("KbdSetBrightness", Napi::Function::New(env, KbdSetBrightness));
   exports.Set("kbdSetModeStarlight", Napi::Function::New(env, KbdSetModeStarlight));
 

--- a/src/driver/addon.cc
+++ b/src/driver/addon.cc
@@ -169,6 +169,20 @@ void KbdSetModeBreathe(const Napi::CallbackInfo &info)
   razer_attr_write_mode_breath(kbdDev, buf, 1);
 }
 
+void KbdSetBrightness(const Napi::CallbackInfo &info)
+{
+  if (kbdDev == NULL)
+  {
+    return;
+  }
+
+  Napi::Number brightness_number = info[0].ToNumber();
+  
+  ushort brightness = brightness_number.Int32Value();
+
+  razer_attr_write_set_brightness(kbdDev, brightness, 1);
+}
+
 void KbdSetModeStarlight(const Napi::CallbackInfo &info)
 {
   Napi::Env env = info.Env();
@@ -896,6 +910,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("kbdSetModeWave", Napi::Function::New(env, KbdSetModeWave));
   exports.Set("kbdSetModeReactive", Napi::Function::New(env, KbdSetModeReactive));
   exports.Set("kbdSetModeBreathe", Napi::Function::New(env, KbdSetModeBreathe));
+  exports.Set("KbdSetBrightness", Napi::Function::New(env, KbdSetBrightness));
   exports.Set("kbdSetModeStarlight", Napi::Function::New(env, KbdSetModeStarlight));
 
   exports.Set("getMouseDevice", Napi::Function::New(env, GetMouseDevice));

--- a/src/driver/razerchromacommon.c
+++ b/src/driver/razerchromacommon.c
@@ -178,7 +178,7 @@ struct razer_report razer_chroma_standard_get_led_effect(unsigned char variable_
  * Status Trans Packet Proto DataSize Class CMD Args
  * ? TODO fill this
  */
-struct razer_report razer_chroma_standard_set_led_brightness(unsigned char variable_storage, unsigned char led_id, unsigned char brightness)
+struct razer_report razer_chroma_standard_set_led_brightness(unsigned char variable_storage, unsigned char led_id, ushort brightness)
 {
     struct razer_report report = get_razer_report(0x03, 0x03, 0x03);
     report.arguments[0] = variable_storage;

--- a/src/driver/razerchromacommon.h
+++ b/src/driver/razerchromacommon.h
@@ -28,7 +28,7 @@ struct razer_report razer_chroma_standard_get_led_rgb(unsigned char variable_sto
 struct razer_report razer_chroma_standard_set_led_effect(unsigned char variable_storage, unsigned char led_id, unsigned char led_effect);
 struct razer_report razer_chroma_standard_get_led_effect(unsigned char variable_storage, unsigned char led_id);
 
-struct razer_report razer_chroma_standard_set_led_brightness(unsigned char variable_storage, unsigned char led_id, unsigned char brightness);
+struct razer_report razer_chroma_standard_set_led_brightness(unsigned char variable_storage, unsigned char led_id, ushort brightness);
 struct razer_report razer_chroma_standard_get_led_brightness(unsigned char variable_storage, unsigned char led_id);
 
 /*

--- a/src/driver/razerkbd_driver.c
+++ b/src/driver/razerkbd_driver.c
@@ -1414,9 +1414,8 @@ ssize_t razer_attr_write_set_fn_toggle(IOUSBDeviceInterface **usb_dev, const cha
  *
  * Sets the brightness to the ASCII number written to this file.
  */
-ssize_t razer_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, const char *buf, int count)
+ssize_t razer_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, ushort brightness, int count)
 {
-    unsigned char brightness = (unsigned char)strtol(buf, NULL, 10);
     struct razer_report report = {0};
 
     UInt16 product = -1;

--- a/src/driver/razerkbd_driver.c
+++ b/src/driver/razerkbd_driver.c
@@ -1477,7 +1477,7 @@ ssize_t razer_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, ushort b
  *
  * Returns a string
  */
-ssize_t razer_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev, char *buf)
+ushort razer_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev)
 {
     unsigned char brightness = 0;
     struct razer_report report = {0};
@@ -1544,7 +1544,9 @@ ssize_t razer_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev, char *buf
         brightness = response.arguments[2];
     }
 
-    return sprintf(buf, "%d\n", brightness);
+    printf("Current keyboard brightness %d\n", brightness);
+
+    return brightness;
 }
 
 /**

--- a/src/driver/razerkbd_driver.h
+++ b/src/driver/razerkbd_driver.h
@@ -149,6 +149,6 @@ ssize_t razer_attr_write_set_logo(IOUSBDeviceInterface **usb_dev, const char *bu
 ssize_t razer_attr_write_mode_custom(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 ssize_t razer_attr_write_set_fn_toggle(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 ssize_t razer_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, ushort brightness, int count);
-ssize_t razer_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev, char *buf);
+ushort razer_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev);
 ssize_t razer_attr_write_matrix_custom_frame(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 #endif

--- a/src/driver/razerkbd_driver.h
+++ b/src/driver/razerkbd_driver.h
@@ -148,7 +148,7 @@ ssize_t razer_attr_read_set_logo(IOUSBDeviceInterface **usb_dev, char *buf, int 
 ssize_t razer_attr_write_set_logo(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 ssize_t razer_attr_write_mode_custom(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 ssize_t razer_attr_write_set_fn_toggle(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
-ssize_t razer_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
+ssize_t razer_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, ushort brightness, int count);
 ssize_t razer_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev, char *buf);
 ssize_t razer_attr_write_matrix_custom_frame(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 #endif

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,13 +1,13 @@
-'use strict'
+'use strict';
 
-import { app, Menu, Tray, BrowserWindow, nativeTheme, ipcMain } from 'electron'
-import addon from '../driver'
-import path from 'path'
-import { format as formatUrl } from 'url'
+import { app, Menu, Tray, BrowserWindow, nativeTheme, ipcMain } from 'electron';
+import addon from '../driver';
+import path from 'path';
+import { format as formatUrl } from 'url';
 
 const storage = require('electron-json-storage');
 
-const isDevelopment = process.env.NODE_ENV == 'development'
+const isDevelopment = process.env.NODE_ENV == 'development';
 
 let tray = null;
 let window = null;
@@ -23,8 +23,7 @@ let cycleColors = null;
 
 function isEmpty(obj) {
   for (var prop in obj) {
-    if (obj.hasOwnProperty(prop))
-      return false;
+    if (obj.hasOwnProperty(prop)) return false;
   }
 
   return true;
@@ -41,8 +40,8 @@ function loadItemsFromStorage() {
         rgb: {
           r: 255,
           g: 255,
-          b: 0
-        }
+          b: 0,
+        },
       };
     }
   });
@@ -57,8 +56,8 @@ function loadItemsFromStorage() {
         rgb: {
           r: 255,
           g: 255,
-          b: 0
-        }
+          b: 0,
+        },
       };
     }
   });
@@ -73,8 +72,8 @@ function loadItemsFromStorage() {
         rgb: {
           r: 255,
           g: 255,
-          b: 0
-        }
+          b: 0,
+        },
       };
     }
   });
@@ -89,13 +88,13 @@ function loadItemsFromStorage() {
         rgb: {
           r: 255,
           g: 255,
-          b: 0
-        }
+          b: 0,
+        },
       };
     }
   });
 
-  storage.get('customHeadphoneColor', function(error, data) {
+  storage.get('customHeadphoneColor', function (error, data) {
     if (error) throw error;
 
     customHeadphoneColor = data;
@@ -105,13 +104,13 @@ function loadItemsFromStorage() {
         rgb: {
           r: 255,
           g: 255,
-          b: 0
-        }
+          b: 0,
+        },
       };
     }
   });
 
-  storage.get('cycleColors', function(error, data) {
+  storage.get('cycleColors', function (error, data) {
     if (error) throw error;
 
     cycleColors = data;
@@ -130,10 +129,10 @@ function loadItemsFromStorage() {
 
 function componentToHex(c) {
   var hex = c.toString(16);
-  return hex.length == 1 ? "0" + hex : hex;
+  return hex.length == 1 ? '0' + hex : hex;
 }
 function rgbToHex({ r, g, b }) {
-  return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+  return '#' + componentToHex(r) + componentToHex(g) + componentToHex(b);
 }
 
 let spectrumColors = [
@@ -153,34 +152,60 @@ let spectrumColors = [
 let cycleColorsIndex = 0;
 let cycleColorsInterval = null;
 function setDevicesCycleColors(colors) {
-  addon.kbdSetModeStaticNoStore(new Uint8Array([
-    colors[cycleColorsIndex].r, colors[cycleColorsIndex].g, colors[cycleColorsIndex].b
-  ]));
-  addon.mouseSetLogoModeStaticNoStore(new Uint8Array([
-    colors[cycleColorsIndex].r, colors[cycleColorsIndex].g, colors[cycleColorsIndex].b
-  ]));
-  addon.mouseDockSetModeStaticNoStore(new Uint8Array([
-    colors[cycleColorsIndex].r, colors[cycleColorsIndex].g, colors[cycleColorsIndex].b
-  ]));
-  addon.mouseMatSetModeStaticNoStore(new Uint8Array([
-    colors[cycleColorsIndex].r, colors[cycleColorsIndex].g, colors[cycleColorsIndex].b
-  ]));
-  addon.egpuSetModeStaticNoStore(new Uint8Array([
-    colors[cycleColorsIndex].r, colors[cycleColorsIndex].g, colors[cycleColorsIndex].b
-  ]));
-  addon.headphoneSetModeStaticNoStore(new Uint8Array([
-    colors[cycleColorsIndex].r, colors[cycleColorsIndex].g, colors[cycleColorsIndex].b
-  ]));
+  addon.kbdSetModeStaticNoStore(
+    new Uint8Array([
+      colors[cycleColorsIndex].r,
+      colors[cycleColorsIndex].g,
+      colors[cycleColorsIndex].b,
+    ])
+  );
+  addon.mouseSetLogoModeStaticNoStore(
+    new Uint8Array([
+      colors[cycleColorsIndex].r,
+      colors[cycleColorsIndex].g,
+      colors[cycleColorsIndex].b,
+    ])
+  );
+  addon.mouseDockSetModeStaticNoStore(
+    new Uint8Array([
+      colors[cycleColorsIndex].r,
+      colors[cycleColorsIndex].g,
+      colors[cycleColorsIndex].b,
+    ])
+  );
+  addon.mouseMatSetModeStaticNoStore(
+    new Uint8Array([
+      colors[cycleColorsIndex].r,
+      colors[cycleColorsIndex].g,
+      colors[cycleColorsIndex].b,
+    ])
+  );
+  addon.egpuSetModeStaticNoStore(
+    new Uint8Array([
+      colors[cycleColorsIndex].r,
+      colors[cycleColorsIndex].g,
+      colors[cycleColorsIndex].b,
+    ])
+  );
+  addon.headphoneSetModeStaticNoStore(
+    new Uint8Array([
+      colors[cycleColorsIndex].r,
+      colors[cycleColorsIndex].g,
+      colors[cycleColorsIndex].b,
+    ])
+  );
 
   cycleColorsIndex++;
-  if (cycleColorsIndex >= colors.length)
-    cycleColorsIndex = 0;
+  if (cycleColorsIndex >= colors.length) cycleColorsIndex = 0;
 }
 
 let mainMenu = [
   {
     label: 'Refresh Device List',
-    click() { refreshDevices(); refreshTray(); },
+    click() {
+      refreshDevices();
+      refreshTray();
+    },
   },
   { type: 'separator' },
   {
@@ -193,13 +218,17 @@ let mainMenu = [
       clearInterval(cycleColorsInterval);
       cycleColorsIndex = 0;
       setDevicesCycleColors(spectrumColors);
-      cycleColorsInterval = setInterval(setDevicesCycleColors, 4000, spectrumColors);
+      cycleColorsInterval = setInterval(
+        setDevicesCycleColors,
+        4000,
+        spectrumColors
+      );
     },
   },
   {
     label: 'Cycle All Devices',
   },
-]
+];
 
 function buildCustomColorsCycleMenu() {
   let cccMenu = [
@@ -209,7 +238,11 @@ function buildCustomColorsCycleMenu() {
         clearInterval(cycleColorsInterval);
         cycleColorsIndex = 0;
         setDevicesCycleColors(cycleColors);
-        cycleColorsInterval = setInterval(setDevicesCycleColors, 4000, cycleColors);
+        cycleColorsInterval = setInterval(
+          setDevicesCycleColors,
+          4000,
+          cycleColors
+        );
       },
     },
     { type: 'separator' },
@@ -219,7 +252,7 @@ function buildCustomColorsCycleMenu() {
         cycleColors = cycleColors.concat({ r: 0x00, g: 0xff, b: 0x00 });
         storage.set('cycleColors', cycleColors);
         refreshTray();
-      }
+      },
     },
     {
       label: 'Reset Colors',
@@ -231,17 +264,17 @@ function buildCustomColorsCycleMenu() {
         ];
         storage.set('cycleColors', cycleColors);
         refreshTray();
-      }
+      },
     },
     { type: 'separator' },
-  ]
+  ];
 
   let index = 0;
-  cycleColors.forEach(element => {
+  cycleColors.forEach((element) => {
     let colorMenuItem = {
       label: 'Color ' + (index + 1),
       indexValue: index,
-      click: event => setCustomCycleColor(event.indexValue),
+      click: (event) => setCustomCycleColor(event.indexValue),
     };
     cccMenu = cccMenu.concat(colorMenuItem);
 
@@ -252,8 +285,14 @@ function buildCustomColorsCycleMenu() {
 }
 
 function setCustomCycleColor(index) {
-  window.webContents.send('device-selected', { device: 'Cycle Color ' + (index + 1), currentColor: { hex: rgbToHex(cycleColors[index]), rgb: cycleColors[index] } });
-  window.show()
+  window.webContents.send('device-selected', {
+    device: 'Cycle Color ' + (index + 1),
+    currentColor: {
+      hex: rgbToHex(cycleColors[index]),
+      rgb: cycleColors[index],
+    },
+  });
+  window.show();
 }
 
 let keyboardMenu = [
@@ -265,7 +304,10 @@ let keyboardMenu = [
   { type: 'separator' },
   {
     label: 'None',
-    click() { clearInterval(cycleColorsInterval); addon.kbdSetModeNone(); },
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.kbdSetModeNone();
+    },
   },
   {
     label: 'Static',
@@ -273,61 +315,71 @@ let keyboardMenu = [
       {
         label: 'Custom color',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStatic(new Uint8Array([
-            customKdbColor.rgb.r, customKdbColor.rgb.g, customKdbColor.rgb.b
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStatic(
+            new Uint8Array([
+              customKdbColor.rgb.r,
+              customKdbColor.rgb.g,
+              customKdbColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'White',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStatic(new Uint8Array([
-            0xff, 0xff, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStatic(new Uint8Array([0xff, 0xff, 0xff]));
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStatic(new Uint8Array([
-            0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStatic(new Uint8Array([0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStatic(new Uint8Array([
-            0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStatic(new Uint8Array([0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStatic(new Uint8Array([
-            0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStatic(new Uint8Array([0, 0, 0xff]));
         },
       },
-    ]
+    ],
   },
   {
     label: 'Wave',
     submenu: [
       {
         label: 'Left',
-        click() { clearInterval(cycleColorsInterval); addon.kbdSetModeWave('left'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeWave('left');
+        },
       },
       {
         label: 'Right',
-        click() { clearInterval(cycleColorsInterval); addon.kbdSetModeWave('right'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeWave('right');
+        },
       },
-    ]
+    ],
   },
   {
     label: 'Spectrum',
-    click() { clearInterval(cycleColorsInterval); addon.kbdSetModeSpectrum(); },
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.kbdSetModeSpectrum();
+    },
   },
   {
     label: 'Reactive',
@@ -335,44 +387,50 @@ let keyboardMenu = [
       {
         label: 'Custom color',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeReactive(new Uint8Array([
-            3, customKdbColor.rgb.r, customKdbColor.rgb.g, customKdbColor.rgb.b
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeReactive(
+            new Uint8Array([
+              3,
+              customKdbColor.rgb.r,
+              customKdbColor.rgb.g,
+              customKdbColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeReactive(new Uint8Array([
-            3, 0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeReactive(new Uint8Array([3, 0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeReactive(new Uint8Array([
-            3, 0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeReactive(new Uint8Array([3, 0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeReactive(new Uint8Array([
-            3, 0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeReactive(new Uint8Array([3, 0, 0, 0xff]));
         },
       },
-    ]
+    ],
   },
   {
     label: 'Breathe',
     click() {
-      clearInterval(cycleColorsInterval); addon.kbdSetModeBreathe(new Uint8Array([
-        0 // random
-      ]))
-    }
+      clearInterval(cycleColorsInterval);
+      addon.kbdSetModeBreathe(
+        new Uint8Array([
+          0, // random
+        ])
+      );
+    },
   },
   {
     label: 'Starlight',
@@ -380,46 +438,71 @@ let keyboardMenu = [
       {
         label: 'Custom color',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStarlight(new Uint8Array([
-            3, customKdbColor.rgb.r, customKdbColor.rgb.g, customKdbColor.rgb.b
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStarlight(
+            new Uint8Array([
+              3,
+              customKdbColor.rgb.r,
+              customKdbColor.rgb.g,
+              customKdbColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStarlight(new Uint8Array([
-            3, 0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStarlight(new Uint8Array([3, 0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStarlight(new Uint8Array([
-            3, 0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStarlight(new Uint8Array([3, 0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.kbdSetModeStarlight(new Uint8Array([
-            3, 0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.kbdSetModeStarlight(new Uint8Array([3, 0, 0, 0xff]));
         },
-      }
-    ]
+      },
+    ],
+  },
+  {
+    label: 'Brightness',
+    submenu: [
+      {
+        label: '0',
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.KbdSetBrightness(0);
+        },
+      },
+      {
+        label: '100',
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.KbdSetBrightness(100);
+        },
+      },
+    ],
   },
   {
     label: 'Set custom color',
     click() {
-      window.webContents.send('device-selected', { device: 'Keyboard', currentColor: customKdbColor });
-      window.setSize(500, 300);
+      window.webContents.send('device-selected', {
+        device: 'Keyboard',
+        currentColor: customKdbColor,
+      });
+      window.setSize(500, 420);
       window.show();
-    }
+    },
   },
-]
+];
 
 let mouseMenu = [
   { type: 'separator' },
@@ -430,7 +513,10 @@ let mouseMenu = [
   { type: 'separator' },
   {
     label: 'None',
-    click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoModeNone(); }
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.mouseSetLogoModeNone();
+    },
   },
   {
     label: 'Static',
@@ -439,61 +525,70 @@ let mouseMenu = [
         label: 'Custom color',
         click() {
           clearInterval(cycleColorsInterval);
-          addon.mouseSetLogoModeStatic(new Uint8Array([
-            customMouseColor.rgb.r, customMouseColor.rgb.g, customMouseColor.rgb.b
-          ]))
+          addon.mouseSetLogoModeStatic(
+            new Uint8Array([
+              customMouseColor.rgb.r,
+              customMouseColor.rgb.g,
+              customMouseColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'White',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeStatic(new Uint8Array([
-            0xff, 0xff, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeStatic(new Uint8Array([0xff, 0xff, 0xff]));
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeStatic(new Uint8Array([
-            0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeStatic(new Uint8Array([0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeStatic(new Uint8Array([
-            0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeStatic(new Uint8Array([0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeStatic(new Uint8Array([
-            0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeStatic(new Uint8Array([0, 0, 0xff]));
         },
       },
-    ]
+    ],
   },
   {
     label: 'Wave',
     submenu: [
       {
         label: 'Left',
-        click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoModeWave('left'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeWave('left');
+        },
       },
       {
         label: 'Right',
-        click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoModeWave('right'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeWave('right');
+        },
       },
-    ]
+    ],
   },
   {
     label: 'Spectrum',
-    click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoModeSpectrum(); },
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.mouseSetLogoModeSpectrum();
+    },
   },
   {
     label: 'Reactive', // Speed currently defaults to 3 until we add speed controls
@@ -502,83 +597,103 @@ let mouseMenu = [
         label: 'Custom color',
         click() {
           clearInterval(cycleColorsInterval);
-          addon.mouseSetLogoModeReactive(new Uint8Array([
-            3, customMouseColor.rgb.r, customMouseColor.rgb.g, customMouseColor.rgb.b
-          ]))
+          addon.mouseSetLogoModeReactive(
+            new Uint8Array([
+              3,
+              customMouseColor.rgb.r,
+              customMouseColor.rgb.g,
+              customMouseColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'White',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeReactive(new Uint8Array([
-            3, 0xff, 0xff, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeReactive(new Uint8Array([3, 0xff, 0xff, 0xff]));
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeReactive(new Uint8Array([
-            3, 0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeReactive(new Uint8Array([3, 0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeReactive(new Uint8Array([
-            3, 0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeReactive(new Uint8Array([3, 0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseSetLogoModeReactive(new Uint8Array([
-            3, 0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoModeReactive(new Uint8Array([3, 0, 0, 0xff]));
         },
       },
-    ]
+    ],
   },
   {
     label: 'Breathe',
     click() {
-      clearInterval(cycleColorsInterval); addon.mouseSetLogoModeBreathe(new Uint8Array([
-        0 // random
-      ]))
-    }
+      clearInterval(cycleColorsInterval);
+      addon.mouseSetLogoModeBreathe(
+        new Uint8Array([
+          0, // random
+        ])
+      );
+    },
   },
   {
     label: 'Older model effects',
     submenu: [
       {
         label: 'Static',
-        click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoLEDEffect('static'); },
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoLEDEffect('static');
+        },
       },
       {
         label: 'Blinking',
-        click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoLEDEffect('blinking'); },
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoLEDEffect('blinking');
+        },
       },
       {
         label: 'Pulsate',
-        click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoLEDEffect('pulsate'); },
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoLEDEffect('pulsate');
+        },
       },
       {
         label: 'Scroll',
-        click() { clearInterval(cycleColorsInterval); addon.mouseSetLogoLEDEffect('scroll'); },
-      }
-    ]
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseSetLogoLEDEffect('scroll');
+        },
+      },
+    ],
   },
   {
     label: 'Set custom color and DPI',
     click() {
-      window.webContents.send('device-selected', { device: 'Mouse', currentColor: customMouseColor, currentSensitivity: addon.mouseGetDpi() });
+      window.webContents.send('device-selected', {
+        device: 'Mouse',
+        currentColor: customMouseColor,
+        currentSensitivity: addon.mouseGetDpi(),
+      });
       window.setSize(500, 420);
       window.show();
-    }
-  }
-]
+    },
+  },
+];
 
 let mouseDockMenu = [
   { type: 'separator' },
@@ -589,7 +704,10 @@ let mouseDockMenu = [
   { type: 'separator' },
   {
     label: 'None',
-    click() { clearInterval(cycleColorsInterval); addon.mouseDockSetModeNone(); }
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.mouseDockSetModeNone();
+    },
   },
   {
     label: 'Static',
@@ -598,66 +716,75 @@ let mouseDockMenu = [
         label: 'Custom color',
         click() {
           clearInterval(cycleColorsInterval);
-          addon.mouseDockSetModeStatic(new Uint8Array([
-            customMouseDockColor.rgb.r, customMouseDockColor.rgb.g, customMouseDockColor.rgb.b
-          ]))
+          addon.mouseDockSetModeStatic(
+            new Uint8Array([
+              customMouseDockColor.rgb.r,
+              customMouseDockColor.rgb.g,
+              customMouseDockColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'White',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseDockSetModeStatic(new Uint8Array([
-            0xff, 0xff, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseDockSetModeStatic(new Uint8Array([0xff, 0xff, 0xff]));
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseDockSetModeStatic(new Uint8Array([
-            0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseDockSetModeStatic(new Uint8Array([0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseDockSetModeStatic(new Uint8Array([
-            0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseDockSetModeStatic(new Uint8Array([0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseDockSetModeStatic(new Uint8Array([
-            0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseDockSetModeStatic(new Uint8Array([0, 0, 0xff]));
         },
       },
-    ]
+    ],
   },
   {
     label: 'Spectrum',
-    click() { clearInterval(cycleColorsInterval); addon.mouseDockSetModeSpectrum(); },
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.mouseDockSetModeSpectrum();
+    },
   },
   {
     label: 'Breathe',
     click() {
-      clearInterval(cycleColorsInterval); addon.mouseDockSetModeBreathe(new Uint8Array([
-        0 // random
-      ]))
-    }
+      clearInterval(cycleColorsInterval);
+      addon.mouseDockSetModeBreathe(
+        new Uint8Array([
+          0, // random
+        ])
+      );
+    },
   },
   {
     label: 'Set custom color',
     click() {
-      window.webContents.send('device-selected', { device: 'Mouse Dock', currentColor: customMouseDockColor });
+      window.webContents.send('device-selected', {
+        device: 'Mouse Dock',
+        currentColor: customMouseDockColor,
+      });
       window.setSize(500, 300);
       window.show();
-    }
+    },
   },
-]
+];
 
 let mouseMatMenu = [
   { type: 'separator' },
@@ -668,7 +795,10 @@ let mouseMatMenu = [
   { type: 'separator' },
   {
     label: 'None',
-    click() { clearInterval(cycleColorsInterval); addon.mouseMatSetModeNone(); }
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.mouseMatSetModeNone();
+    },
   },
   {
     label: 'Static',
@@ -677,79 +807,94 @@ let mouseMatMenu = [
         label: 'Custom color',
         click() {
           clearInterval(cycleColorsInterval);
-          addon.mouseMatSetModeStatic(new Uint8Array([
-            customMouseMatColor.rgb.r, customMouseMatColor.rgb.g, customMouseMatColor.rgb.b
-          ]))
+          addon.mouseMatSetModeStatic(
+            new Uint8Array([
+              customMouseMatColor.rgb.r,
+              customMouseMatColor.rgb.g,
+              customMouseMatColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'White',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseMatSetModeStatic(new Uint8Array([
-            0xff, 0xff, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseMatSetModeStatic(new Uint8Array([0xff, 0xff, 0xff]));
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseMatSetModeStatic(new Uint8Array([
-            0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseMatSetModeStatic(new Uint8Array([0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseMatSetModeStatic(new Uint8Array([
-            0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseMatSetModeStatic(new Uint8Array([0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.mouseMatSetModeStatic(new Uint8Array([
-            0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.mouseMatSetModeStatic(new Uint8Array([0, 0, 0xff]));
         },
       },
-    ]
+    ],
   },
   {
     label: 'Wave',
     submenu: [
       {
         label: 'Left',
-        click() { clearInterval(cycleColorsInterval); addon.mouseMatSetModeWave('left'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseMatSetModeWave('left');
+        },
       },
       {
         label: 'Right',
-        click() { clearInterval(cycleColorsInterval); addon.mouseMatSetModeWave('right'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.mouseMatSetModeWave('right');
+        },
       },
-    ]
+    ],
   },
   {
     label: 'Spectrum',
-    click() { clearInterval(cycleColorsInterval); addon.mouseMatSetModeSpectrum(); },
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.mouseMatSetModeSpectrum();
+    },
   },
   {
     label: 'Breathe',
     click() {
-      clearInterval(cycleColorsInterval); addon.mouseMatSetModeBreathe(new Uint8Array([
-        0 // random
-      ]))
-    }
+      clearInterval(cycleColorsInterval);
+      addon.mouseMatSetModeBreathe(
+        new Uint8Array([
+          0, // random
+        ])
+      );
+    },
   },
   {
     label: 'Set custom color',
     click() {
-      window.webContents.send('device-selected', { device: 'Mouse Mat', currentColor: customMouseMatColor });
-      window.setSize(500, 300);
+      window.webContents.send('device-selected', {
+        device: 'Mouse Mat',
+        currentColor: customMouseMatColor,
+      });
+      window.setSize(500, 400);
       window.show();
-    }
+    },
   },
-]
+];
 
 let egpuMenu = [
   { type: 'separator' },
@@ -760,7 +905,10 @@ let egpuMenu = [
   { type: 'separator' },
   {
     label: 'None',
-    click() { clearInterval(cycleColorsInterval); addon.egpuSetModeNone(); }
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.egpuSetModeNone();
+    },
   },
   {
     label: 'Static',
@@ -769,79 +917,94 @@ let egpuMenu = [
         label: 'Custom color',
         click() {
           clearInterval(cycleColorsInterval);
-          addon.egpuSetModeStatic(new Uint8Array([
-            customegpuColor.rgb.r, customegpuColor.rgb.g, customegpuColor.rgb.b
-          ]))
+          addon.egpuSetModeStatic(
+            new Uint8Array([
+              customegpuColor.rgb.r,
+              customegpuColor.rgb.g,
+              customegpuColor.rgb.b,
+            ])
+          );
         },
       },
       {
         label: 'White',
         click() {
-          clearInterval(cycleColorsInterval); addon.egpuSetModeStatic(new Uint8Array([
-            0xff, 0xff, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.egpuSetModeStatic(new Uint8Array([0xff, 0xff, 0xff]));
         },
       },
       {
         label: 'Red',
         click() {
-          clearInterval(cycleColorsInterval); addon.egpuSetModeStatic(new Uint8Array([
-            0xff, 0, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.egpuSetModeStatic(new Uint8Array([0xff, 0, 0]));
         },
       },
       {
         label: 'Green',
         click() {
-          clearInterval(cycleColorsInterval); addon.egpuSetModeStatic(new Uint8Array([
-            0, 0xff, 0
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.egpuSetModeStatic(new Uint8Array([0, 0xff, 0]));
         },
       },
       {
         label: 'Blue',
         click() {
-          clearInterval(cycleColorsInterval); addon.egpuSetModeStatic(new Uint8Array([
-            0, 0, 0xff
-          ]))
+          clearInterval(cycleColorsInterval);
+          addon.egpuSetModeStatic(new Uint8Array([0, 0, 0xff]));
         },
       },
-    ]
+    ],
   },
   {
     label: 'Wave',
     submenu: [
       {
         label: 'Left',
-        click() { clearInterval(cycleColorsInterval); addon.egpuSetModeWave('left'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.egpuSetModeWave('left');
+        },
       },
       {
         label: 'Right',
-        click() { clearInterval(cycleColorsInterval); addon.egpuSetModeWave('right'); }
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.egpuSetModeWave('right');
+        },
       },
-    ]
+    ],
   },
   {
     label: 'Spectrum',
-    click() { clearInterval(cycleColorsInterval); addon.egpuSetModeSpectrum(); },
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.egpuSetModeSpectrum();
+    },
   },
   {
     label: 'Breathe',
     click() {
-      clearInterval(cycleColorsInterval); addon.egpuSetModeBreathe(new Uint8Array([
-        0 // random
-      ]))
-    }
+      clearInterval(cycleColorsInterval);
+      addon.egpuSetModeBreathe(
+        new Uint8Array([
+          0, // random
+        ])
+      );
+    },
   },
   {
     label: 'Set custom color',
     click() {
-      window.webContents.send('device-selected', { device: 'Mouse Mat', currentColor: customegpuColor });
+      window.webContents.send('device-selected', {
+        device: 'Mouse Mat',
+        currentColor: customegpuColor,
+      });
       window.setSize(500, 300);
       window.show();
-    }
+    },
   },
-]
+];
 
 let headphoneMenu = [
   { type: 'separator' },
@@ -852,7 +1015,10 @@ let headphoneMenu = [
   { type: 'separator' },
   {
     label: 'None',
-    click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeNone(); }
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.headphoneSetModeNone();
+    },
   },
   {
     label: 'Static',
@@ -861,59 +1027,78 @@ let headphoneMenu = [
         label: 'Custom color',
         click() {
           clearInterval(cycleColorsInterval);
-          addon.headphoneSetModeStatic(new Uint8Array([
-            customHeadphoneColor.rgb.r, customHeadphoneColor.rgb.g, customHeadphoneColor.rgb.b
-          ]))},
+          addon.headphoneSetModeStatic(
+            new Uint8Array([
+              customHeadphoneColor.rgb.r,
+              customHeadphoneColor.rgb.g,
+              customHeadphoneColor.rgb.b,
+            ])
+          );
+        },
       },
       {
         label: 'White',
-        click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeStatic(new Uint8Array([
-          0xff,0xff,0xff
-        ]))},
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.headphoneSetModeStatic(new Uint8Array([0xff, 0xff, 0xff]));
+        },
       },
       {
         label: 'Red',
-        click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeStatic(new Uint8Array([
-          0xff,0,0
-        ]))},
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.headphoneSetModeStatic(new Uint8Array([0xff, 0, 0]));
+        },
       },
       {
         label: 'Green',
-        click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeStatic(new Uint8Array([
-          0,0xff,0
-        ]))},
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.headphoneSetModeStatic(new Uint8Array([0, 0xff, 0]));
+        },
       },
       {
         label: 'Blue',
-        click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeStatic(new Uint8Array([
-          0,0,0xff
-        ]))},
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.headphoneSetModeStatic(new Uint8Array([0, 0, 0xff]));
+        },
       },
-    ]
+    ],
   },
   {
     label: 'Breathe',
-    click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeBreathe(new Uint8Array([
-      0 // random
-    ]))}
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.headphoneSetModeBreathe(
+        new Uint8Array([
+          0, // random
+        ])
+      );
+    },
   },
   {
     label: 'Set custom color',
     click() {
-      window.webContents.send('device-selected', {device: 'Headphone', currentColor: customHeadphoneColor});
+      window.webContents.send('device-selected', {
+        device: 'Headphone',
+        currentColor: customHeadphoneColor,
+      });
       window.setSize(500, 300);
       window.show();
-    }
-  }
-]
+    },
+  },
+];
 
 let mainMenuBottom = [
   { type: 'separator' },
   {
     label: 'Quit',
-    click() { app.quit(); }
+    click() {
+      app.quit();
+    },
   },
-]
+];
 
 let keyboardDeviceName = '';
 let mouseDeviceName = '';
@@ -926,12 +1111,12 @@ let mouseCharging = false;
 
 const refreshDevices = () => {
   // close devices
-  addon.closeKeyboardDevice()
-  addon.closeMouseDevice()
-  addon.closeMouseDockDevice()
-  addon.closeMouseMatDevice()
-  addon.closeEgpuDevice()
-  addon.closeHeadphoneDevice()
+  addon.closeKeyboardDevice();
+  addon.closeMouseDevice();
+  addon.closeMouseDockDevice();
+  addon.closeMouseMatDevice();
+  addon.closeEgpuDevice();
+  addon.closeHeadphoneDevice();
 
   // get devices
   keyboardDeviceName = addon.getKeyboardDevice();
@@ -942,18 +1127,16 @@ const refreshDevices = () => {
   mouseBatteryLevel = addon.getBatteryLevel();
   mouseCharging = addon.getChargingStatus();
   headphoneDeviceName = addon.getHeadphoneDevice();
-}
+};
 
 app.on('ready', () => {
   loadItemsFromStorage();
-})
+});
 function itemsLoadedFromStorage() {
   refreshDevices();
   createTray();
   createWindow();
 }
-
-
 
 app.on('quit', () => {
   addon.closeKeyboardDevice();
@@ -962,17 +1145,23 @@ app.on('quit', () => {
   addon.closeMouseMatDevice();
   addon.closeEgpuDevice();
   addon.closeHeadphoneDevice();
-})
+});
 
 nativeTheme.on('updated', () => {
   createTray();
-})
+});
 
 // mouse dpi rpc listener
 ipcMain.on('request-set-dpi', (event, arg) => {
   const { dpi } = arg;
   addon.mouseSetDpi(dpi);
-})
+});
+
+// keyboard brightness rpc listener
+ipcMain.on('update-keyboard-brightness', (_, arg) => {
+  const { brightness } = arg;
+  addon.KbdSetBrightness(brightness);
+});
 
 // custom color rpc listener
 ipcMain.on('request-set-custom-color', (event, arg) => {
@@ -982,30 +1171,29 @@ ipcMain.on('request-set-custom-color', (event, arg) => {
     let index = Number.parseInt(device.substring(12)) - 1;
     cycleColors[index] = color.rgb;
     storage.set('cycleColors', cycleColors);
-  }
-  else {
+  } else {
     switch (device) {
-      case "Keyboard":
+      case 'Keyboard':
         customKdbColor = color;
         storage.set('customKdbColor', customKdbColor);
         break;
-      case "Mouse":
+      case 'Mouse':
         customMouseColor = color;
         storage.set('customMouseColor', customMouseColor);
         break;
-      case "Mouse Dock":
+      case 'Mouse Dock':
         customMouseDockColor = color;
         storage.set('customMouseDockColor', customMouseDockColor);
         break;
-      case "Mouse Mat":
+      case 'Mouse Mat':
         customMouseMatColor = color;
         storage.set('customMouseMatColor', customMouseMatColor);
         break;
-      case "eGPU":
+      case 'eGPU':
         customMouseMatColor = color;
         storage.set('customMouseMatColor', customMouseMatColor);
         break;
-      case "Headphone":
+      case 'Headphone':
         customHeadphoneColor = color;
         storage.set('customHeadphoneColor', customHeadphoneColor);
         break;
@@ -1014,31 +1202,31 @@ ipcMain.on('request-set-custom-color', (event, arg) => {
   }
 });
 
-
 function createWindow() {
   window = new BrowserWindow({
     webPreferences: { nodeIntegration: true },
     titleBarStyle: 'hidden',
-    height: 300,
+    height: 420,
     resizable: false,
     width: 500,
     y: 100,
     // Set the default background color of the window to match the CSS
     // background color of the page, this prevents any white flickering
-    backgroundColor: "#242424",
+    backgroundColor: '#242424',
     // Don't show the window until it's ready, this prevents any white flickering
     show: false,
-  })
+  });
   if (isDevelopment) {
-    window.loadURL(`http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}`)
+    window.loadURL(`http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}`);
     window.resizable = true;
-  }
-  else {
-    window.loadURL(formatUrl({
-      pathname: path.join(__dirname, 'index.html'),
-      protocol: 'file',
-      slashes: true
-    }))
+  } else {
+    window.loadURL(
+      formatUrl({
+        pathname: path.join(__dirname, 'index.html'),
+        protocol: 'file',
+        slashes: true,
+      })
+    );
   }
   window.webContents.on('did-finish-load', () => {
     // Handle window logic properly on macOS:
@@ -1076,7 +1264,7 @@ function createWindow() {
         ]).popup(window);
       });
     }
-  })
+  });
 }
 
 function createTray() {
@@ -1094,7 +1282,7 @@ function createTray() {
     tray = new Tray(path.join(__static, '/assets/icon-lightmode.png'));
   }
 
-  refreshTray()
+  refreshTray();
 }
 
 function refreshTray() {
@@ -1110,10 +1298,13 @@ function refreshTray() {
     if (mouseBatteryLevel == -1) {
       mouseMenu[1].label = mouseDeviceName;
     } else if (mouseCharging) {
-      mouseMenu[1].label = mouseDeviceName.concat(" - ⚡".concat(mouseBatteryLevel.toString().concat("%")));
-    }
-    else {
-      mouseMenu[1].label = mouseDeviceName.concat(" - 🔋".concat(mouseBatteryLevel.toString().concat("%")));
+      mouseMenu[1].label = mouseDeviceName.concat(
+        ' - ⚡'.concat(mouseBatteryLevel.toString().concat('%'))
+      );
+    } else {
+      mouseMenu[1].label = mouseDeviceName.concat(
+        ' - 🔋'.concat(mouseBatteryLevel.toString().concat('%'))
+      );
     }
     menu = menu.concat(mouseMenu);
   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -476,14 +476,19 @@ let keyboardMenu = [
     label: 'Brightness',
     submenu: [
       {
-        label: '0',
+        label: 'Brightness info not found',
+        enabled: false,
+      },
+      { type: 'separator' },
+      {
+        label: 'Set to 0%',
         click() {
           clearInterval(cycleColorsInterval);
           addon.KbdSetBrightness(0);
         },
       },
       {
-        label: '100',
+        label: 'Set to 100%',
         click() {
           clearInterval(cycleColorsInterval);
           addon.KbdSetBrightness(100);
@@ -492,11 +497,14 @@ let keyboardMenu = [
     ],
   },
   {
-    label: 'Set custom color',
+    label: 'Set custom color and brightness',
     click() {
+      const currentBrightness = addon.KbdGetBrightness();
       window.webContents.send('device-selected', {
         device: 'Keyboard',
         currentColor: customKdbColor,
+        // getBrightness could give -1 when not keyboard not detected
+        currentBrightness: currentBrightness < 0 ? 0 : currentBrightness,
       });
       window.setSize(500, 420);
       window.show();
@@ -1101,6 +1109,7 @@ let mainMenuBottom = [
 ];
 
 let keyboardDeviceName = '';
+let keyboardBrightnessLevel = -1;
 let mouseDeviceName = '';
 let mouseDockDeviceName = '';
 let mouseMatDeviceName = '';
@@ -1120,6 +1129,7 @@ const refreshDevices = () => {
 
   // get devices
   keyboardDeviceName = addon.getKeyboardDevice();
+  keyboardBrightnessLevel = addon.KbdGetBrightness();
   mouseDeviceName = addon.getMouseDevice();
   mouseDockDeviceName = addon.getMouseDockDevice();
   mouseMatDeviceName = addon.getMouseMatDevice();
@@ -1292,6 +1302,7 @@ function refreshTray() {
   let menu = mainMenu;
   if (keyboardDeviceName) {
     keyboardMenu[1].label = keyboardDeviceName;
+    keyboardMenu[10].submenu[0].label = `Brightness: ${keyboardBrightnessLevel}%`;
     menu = menu.concat(keyboardMenu);
   }
   if (mouseDeviceName) {

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -1,45 +1,51 @@
 import React, { useState, useEffect } from 'react';
-import CustomColor from './components/CustomColor'
+import CustomColor from './components/CustomColor';
 import { ipcRenderer } from 'electron';
 import MouseSensitivity from './components/MouseSensitivity';
+import Brightness from './components/Brightness/Brightness';
 
 /**
  * Root React component
  */
 export default function App() {
-    const INITIAL_COLOR = {}
+  const INITIAL_COLOR = {};
 
-    const [deviceSelected, setDeviceSelected] = useState('Keyboard');
-    const [currentColor, setCurrentColor] = useState(INITIAL_COLOR);
-    const [currentSensitivity, setCurrentSensitivity] = useState(3200);
+  const [deviceSelected, setDeviceSelected] = useState('Keyboard');
+  const [currentColor, setCurrentColor] = useState(INITIAL_COLOR);
+  const [currentSensitivity, setCurrentSensitivity] = useState(3200);
 
-    useEffect( () => {
-        ipcRenderer.on('device-selected', (event, message) => { 
-          if (message.currentSensitivity != null) {
-            setCurrentSensitivity(message.currentSensitivity)
-          }
-          setDeviceSelected(message.device);
-          setCurrentColor(message.currentColor);
+  useEffect(() => {
+    ipcRenderer.on('device-selected', (event, message) => {
+      if (message.currentSensitivity != null) {
+        setCurrentSensitivity(message.currentSensitivity);
+      }
+      setDeviceSelected(message.device);
+      setCurrentColor(message.currentColor);
+    });
+  }, []);
 
-        });
-                
-    }, []);
-
-    return (
+  return (
     <div>
-        <header id="titlebar">
-          <div id="drag-region">
-            <div id="window-title">
-              <span>{deviceSelected} custom color picker</span>
-            </div>
+      <header id="titlebar">
+        <div id="drag-region">
+          <div id="window-title">
+            <span>{deviceSelected} custom color picker</span>
           </div>
-        </header>
+        </div>
+      </header>
 
-        <CustomColor deviceSelected={deviceSelected} currentColor={currentColor} setCurrentColor={setCurrentColor}/>
-        {deviceSelected == 'Mouse' && 
-          <MouseSensitivity currentSensitivity={currentSensitivity} ></MouseSensitivity>
-        }
-        
-    </div>);
-
+      <CustomColor
+        deviceSelected={deviceSelected}
+        currentColor={currentColor}
+        setCurrentColor={setCurrentColor}
+      />
+      {deviceSelected == 'Mouse' && (
+        <MouseSensitivity
+          currentSensitivity={currentSensitivity}
+        ></MouseSensitivity>
+      )}
+      {/* TODO: Update currentBrightness to read from device */}
+      {deviceSelected === 'Keyboard' && <Brightness currentBrightness={0} />}
+    </div>
+  );
 }

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -13,16 +13,32 @@ export default function App() {
   const [deviceSelected, setDeviceSelected] = useState('Keyboard');
   const [currentColor, setCurrentColor] = useState(INITIAL_COLOR);
   const [currentSensitivity, setCurrentSensitivity] = useState(3200);
+  // 0-100. In debug mode, this will be set to 50 when the UI is loaded
+  const [currentBrightness, setCurrentBrightness] = useState(50);
 
   useEffect(() => {
     ipcRenderer.on('device-selected', (event, message) => {
       if (message.currentSensitivity != null) {
         setCurrentSensitivity(message.currentSensitivity);
       }
+      if (message.currentBrightness != null) {
+        setCurrentBrightness(message.currentBrightness);
+      }
       setDeviceSelected(message.device);
       setCurrentColor(message.currentColor);
     });
   }, []);
+
+  useEffect(() => {
+    let payload = {
+      brightness: currentBrightness,
+    };
+    ipcRenderer.send('update-keyboard-brightness', payload);
+  }, [currentBrightness]);
+
+  const handleBrightnessChange = (value) => {
+    setCurrentBrightness(value);
+  };
 
   return (
     <div>
@@ -44,8 +60,12 @@ export default function App() {
           currentSensitivity={currentSensitivity}
         ></MouseSensitivity>
       )}
-      {/* TODO: Update currentBrightness to read from device */}
-      {deviceSelected === 'Keyboard' && <Brightness currentBrightness={0} />}
+      {deviceSelected === 'Keyboard' && (
+        <Brightness
+          brightness={currentBrightness}
+          onBrightnessChange={handleBrightnessChange}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/components/Brightness/Brightness.jsx
+++ b/src/renderer/components/Brightness/Brightness.jsx
@@ -2,20 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ipcRenderer } from 'electron';
 import ReactSlider from 'react-slider';
 
-export default function Brightness({ currentBrightness }) {
-  const [brightness, setBrightness] = useState(currentBrightness);
-
-  useEffect(() => {
-    let payload = {
-      brightness,
-    };
-    ipcRenderer.send('update-keyboard-brightness', payload);
-  }, [brightness]);
-
-  const changeSliderValue = (value) => {
-    setBrightness(value);
-  };
-
+export default function Brightness({ brightness, onBrightnessChange }) {
   return (
     <div className="settings">
       <h4>Adjust keyboard brightness</h4>
@@ -28,8 +15,10 @@ export default function Brightness({ currentBrightness }) {
           min={0}
           max={100}
           value={brightness}
-          onChange={changeSliderValue}
-          renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
+          onChange={onBrightnessChange}
+          renderThumb={(props, state) => (
+            <div {...props}>{state.valueNow + '%'}</div>
+          )}
         ></ReactSlider>
       </div>
     </div>

--- a/src/renderer/components/Brightness/Brightness.jsx
+++ b/src/renderer/components/Brightness/Brightness.jsx
@@ -2,37 +2,35 @@ import React, { useState, useEffect } from 'react';
 import { ipcRenderer } from 'electron';
 import ReactSlider from 'react-slider';
 
-export default function MouseSensitivity({ currentSensitivity }) {
-  const [currentDpi, setCurrentDpi] = useState(currentSensitivity);
+export default function Brightness({ currentBrightness }) {
+  const [brightness, setBrightness] = useState(currentBrightness);
 
-  const handleClick = () => {
+  useEffect(() => {
     let payload = {
-      dpi: currentDpi,
+      brightness,
     };
-    ipcRenderer.send('request-set-dpi', payload);
-  };
+    ipcRenderer.send('update-keyboard-brightness', payload);
+  }, [brightness]);
 
   const changeSliderValue = (value) => {
-    setCurrentDpi(value);
+    setBrightness(value);
   };
 
   return (
     <div className="settings">
+      <h4>Adjust keyboard brightness</h4>
       <div className="control">
         <ReactSlider
-          step={100}
+          step={1}
           className="horizontal-slider"
           thumbClassName="slider-thumb"
           trackClassName="slider-track"
-          min={100}
-          max={20000}
-          value={currentDpi}
+          min={0}
+          max={100}
+          value={brightness}
           onChange={changeSliderValue}
           renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
         ></ReactSlider>
-      </div>
-      <div className="control">
-        <button onClick={handleClick}>Set DPI</button>
       </div>
     </div>
   );

--- a/src/renderer/components/Brightness/index.jsx
+++ b/src/renderer/components/Brightness/index.jsx
@@ -1,0 +1,1 @@
+export * from "./Brightness";

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1,64 +1,72 @@
-
 body {
-    margin: 3px;
+  margin: 3px;
 }
 
-
 .settings {
-    margin: 30px 10px 30px 10px;
-    /* -webkit-app-region: no-drag; */
+  margin: 30px 10px 30px 10px;
+  /* -webkit-app-region: no-drag; */
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: white;
+  text-align: center;
 }
 
 .control {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
 }
 
 #titlebar {
-    color: #FFF;
+  color: #fff;
 }
 
 #titlebar #drag-region {
-    -webkit-app-region: drag;
+  -webkit-app-region: drag;
 }
-  
+
 #window-title {
-    text-align: center;
-    overflow: hidden;
-    font-family: "SF Display Pro", sans-serif;
-    font-size: 12px;
+  text-align: center;
+  overflow: hidden;
+  font-family: 'SF Display Pro', sans-serif;
+  font-size: 12px;
 }
-  
+
 #window-title span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.5;
 }
 
 .horizontal-slider {
-    width: 100%;
-    max-width: 500px;
-    height: 50px;
+  width: 100%;
+  max-width: 500px;
+  height: 50px;
 }
 
-.horizontal-slider .dpi-track {
-    top: 16px;
-    height: 16px;
-    background-color: rgb(51,42,245);
-    border-radius: 24px;
+.horizontal-slider .slider-track {
+  top: 16px;
+  height: 16px;
+  background-color: rgb(51, 42, 245);
+  border-radius: 24px;
 }
 
-.horizontal-slider .dpi-thumb {
-    top: 6px;
-    width: 36px;
-    height: 36px;
-    line-height: 36px;
-    background-color: white;
-    text-align: center;
-    border-radius: 24px;
-    font-family: "SF Display Pro", sans-serif;
-    font-size: 12px;
+.horizontal-slider .slider-thumb {
+  top: 6px;
+  width: 36px;
+  height: 36px;
+  line-height: 36px;
+  background-color: white;
+  text-align: center;
+  border-radius: 24px;
+  font-family: 'SF Display Pro', sans-serif;
+  font-size: 12px;
 }


### PR DESCRIPTION
- Updated the menu with additional 'Brightness' sub-menus
- Updated keyboard UI with Brightness slider, which update on the fly without using an update button like existing controls.
- Did not update readme with keyboard support list

<img width="396" alt="Screenshot Menu Brightness" src="https://user-images.githubusercontent.com/5257855/102031314-82eae200-3dad-11eb-9fdd-784c89a8306f.png">
<img width="612" alt="Screenshot Keyboard UI Change" src="https://user-images.githubusercontent.com/5257855/102031318-84b4a580-3dad-11eb-98ac-f64f4589a625.png">


**Note** I'm a React dev with little C++ knowledge from uni, please pay special attention to the C++ changes. 

I have only tested this with my Blackwidow Ultimate 2013 keyboard, with single green color back light. None of the other functionalities has any effect on my keyboard, which I kind of understand given most of the code handles chroma effects.

I have prettier installed and auto-formatted `js` files, which might be good a idea to include a shared setting at root level, which i can look into in another PR if needed.
