### PR TITLE
Add basic support for (other) Razer Kraken devices

### DIFF
--- a/src/driver/addon.cc
+++ b/src/driver/addon.cc
@@ -886,6 +886,15 @@ void HeadphoneSetModeNone(const Napi::CallbackInfo &info)
     razer_headphone_attr_write_mode_none(headphoneDev, "1", 1);
 }
 
+void HeadphoneSetModeSpectrum(const Napi::CallbackInfo &info)
+{
+    if (headphoneDev == NULL)
+    {
+        return;
+    }
+    razer_headphone_attr_write_mode_spectrum(headphoneDev, "1", 1);
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("getKeyboardDevice", Napi::Function::New(env, GetKeyboardDevice));
   exports.Set("closeKeyboardDevice", Napi::Function::New(env, CloseKeyboardDevice));
@@ -951,6 +960,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("headphoneSetModeBreathe", Napi::Function::New(env, HeadphoneSetModeBreathe));
   exports.Set("headphoneSetModeStatic", Napi::Function::New(env, HeadphoneSetModeStatic));
   exports.Set("headphoneSetModeStaticNoStore", Napi::Function::New(env, HeadphoneSetModeStaticNoStore));
+  exports.Set("headphoneSetModeSpectrum", Napi::Function::New(env, HeadphoneSetModeSpectrum));
 
   return exports;
 }

--- a/src/driver/razerdevice.c
+++ b/src/driver/razerdevice.c
@@ -175,6 +175,7 @@ bool is_headphone(IOUSBDeviceInterface **usb_dev)
     switch (product) 
     {
         case USB_DEVICE_ID_RAZER_KRAKEN_KITTY_EDITION:
+        case USB_DEVICE_ID_RAZER_KRAKEN_V2:
             return true;
     }
 

--- a/src/driver/razerdevice.h
+++ b/src/driver/razerdevice.h
@@ -14,6 +14,7 @@
 #include "razermousemat_driver.h"
 #include "razerheadphone_driver.h"
 #include "razeregpu_driver.h"
+#include "razerkraken_driver.h"
 
 #define TYPE_KEYBOARD 0
 #define TYPE_BLADE 1

--- a/src/driver/razerheadphone_driver.h
+++ b/src/driver/razerheadphone_driver.h
@@ -22,5 +22,6 @@ ssize_t razer_headphone_attr_write_mode_none(IOUSBDeviceInterface **usb_dev, con
 ssize_t razer_headphone_attr_write_mode_breath(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
 ssize_t razer_headphone_attr_write_mode_static(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
 ssize_t razer_headphone_attr_write_mode_static_no_store(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
+ssize_t razer_headphone_attr_write_mode_spectrum(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
 
 #endif

--- a/src/driver/razerkraken_driver.c
+++ b/src/driver/razerkraken_driver.c
@@ -1,0 +1,324 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Should you need to contact me, the author, you can do so by
+ * e-mail - mail your message to Terry Cain <terry@terrys-home.co.uk>
+ */
+
+#include <usb.h>
+#include <libc.h>
+#include "razerkraken_driver.h"
+#include "razercommon.h"
+
+/**
+ * Send USB control report to the keyboard
+ * USUALLY index = 0x02
+ * FIREFLY is 0
+ */
+IOReturn razer_kraken_send_control_msg(IOUSBDeviceInterface **dev, struct razer_kraken_request_report* data, unsigned char skip) {
+    IOUSBDevRequest request;
+
+    request.bRequest = HID_REQ_SET_REPORT; // 0x09
+    request.bmRequestType = USB_TYPE_CLASS | USB_RECIP_INTERFACE | USB_DIR_OUT;
+    request.wValue = 0x0204;
+    request.wIndex = 0x0003;
+    request.wLength = 37;
+    request.pData = (void*)data;
+
+    IOReturn result = (*dev)->DeviceRequest(dev, &request);
+
+    // Wait
+    if(skip != 1) {
+        usleep(data->length * 15 * 1000);
+    }
+    return result;
+}
+
+static struct razer_kraken_device get_kraken_device(IOUSBDeviceInterface **dev)
+{
+    UInt16 product = -1;
+    (*dev)->GetDeviceProduct(dev, &product);
+
+    struct razer_kraken_device device;
+    device.usb_pid = product;
+
+    switch (product)
+    {
+        case USB_DEVICE_ID_RAZER_KRAKEN_V2:
+            device.led_mode_address = KYLIE_SET_LED_ADDRESS;
+            device.custom_address = KYLIE_CUSTOM_ADDRESS_START;
+            device.breathing_address[0] = KYLIE_BREATHING1_ADDRESS_START;
+            device.breathing_address[1] = KYLIE_BREATHING2_ADDRESS_START;
+            device.breathing_address[2] = KYLIE_BREATHING3_ADDRESS_START;
+            break;
+    }
+
+    return device;
+}
+
+/**
+ * Get a request report
+ *
+ * report_id - The type of report
+ * destination - where data is going (like ram)
+ * length - amount of data
+ * address - where to write data to
+ */
+static struct razer_kraken_request_report get_kraken_request_report(unsigned char report_id, unsigned char destination, unsigned char length, unsigned short address)
+{
+    struct razer_kraken_request_report report;
+    memset(&report, 0, sizeof(struct razer_kraken_request_report));
+
+    report.report_id = report_id;
+    report.destination = destination;
+    report.length = length;
+    report.addr_h = (address >> 8);
+    report.addr_l = (address & 0xFF);
+
+    return report;
+}
+
+/**
+ * Get a union containing the effect bitfield
+ */
+static union razer_kraken_effect_byte get_kraken_effect_byte(void)
+{
+    union razer_kraken_effect_byte effect_byte;
+    memset(&effect_byte, 0, sizeof(union razer_kraken_effect_byte));
+
+    return effect_byte;
+}
+
+/**
+ * Write device file "mode_spectrum"
+ *
+ * Specrum effect mode is activated whenever the file is written to
+ */
+ssize_t razer_kraken_attr_write_mode_spectrum(IOUSBDeviceInterface **dev, const char *buf, size_t count)
+{
+    struct razer_kraken_device device = get_kraken_device(dev);
+    struct razer_kraken_request_report report = get_kraken_request_report(0x04, 0x40, 0x01, device.led_mode_address);
+    union razer_kraken_effect_byte effect_byte = get_kraken_effect_byte();
+
+    // Spectrum Cycling | ON
+    effect_byte.bits.on_off_static = 1;
+    effect_byte.bits.spectrum_cycling = 1;
+
+    report.arguments[0] = effect_byte.value;
+
+    // Lock access to sending USB as adhering to the razer len*15ms delay
+    razer_kraken_send_control_msg(dev, &report, 0);
+
+    return count;
+}
+
+/**
+ * Write device file "mode_none"
+ *
+ * None effect mode is activated whenever the file is written to
+ */
+ssize_t razer_kraken_attr_write_mode_none(IOUSBDeviceInterface **dev, const char *buf, size_t count)
+{
+    struct razer_kraken_device device = get_kraken_device(dev);
+    struct razer_kraken_request_report report = get_kraken_request_report(0x04, 0x40, 0x01, device.led_mode_address);
+    union razer_kraken_effect_byte effect_byte = get_kraken_effect_byte();
+
+    // Spectrum Cycling | OFF
+    effect_byte.bits.on_off_static = 0;
+    effect_byte.bits.spectrum_cycling = 0;
+
+    report.arguments[0] = effect_byte.value;
+
+    // Lock access to sending USB as adhering to the razer len*15ms delay
+    razer_kraken_send_control_msg(dev, &report, 0);
+
+    return count;
+}
+
+
+/**
+ * Write device file "mode_static"
+ *
+ * Static effect mode is activated whenever the file is written to with 3 bytes
+ */
+ssize_t razer_kraken_attr_write_mode_static(IOUSBDeviceInterface **dev, const char *buf, size_t count)
+{
+    struct razer_kraken_device device = get_kraken_device(dev);
+    struct razer_kraken_request_report rgb_report = get_kraken_request_report(0x04, 0x40, count, device.breathing_address[0]);
+    struct razer_kraken_request_report effect_report = get_kraken_request_report(0x04, 0x40, 0x01, device.led_mode_address);
+    union razer_kraken_effect_byte effect_byte = get_kraken_effect_byte();
+
+    if(count == 3 || count == 4) {
+
+        rgb_report.arguments[0] = buf[0];
+        rgb_report.arguments[1] = buf[1];
+        rgb_report.arguments[2] = buf[2];
+
+        if(count == 4) {
+            rgb_report.arguments[3] = buf[3];
+        }
+
+        // ON/Static
+        effect_byte.bits.on_off_static = 1;
+        effect_report.arguments[0] = effect_byte.value;
+
+        // Basically Kraken Classic doesn't take RGB arguments so only do it for the KrakenV1,V2,Ultimate
+        switch(device.usb_pid) {
+            case USB_DEVICE_ID_RAZER_KRAKEN_V2:
+                razer_kraken_send_control_msg(dev, &rgb_report, 0);
+                break;
+        }
+        // Send Set static command
+        razer_kraken_send_control_msg(dev, &effect_report, 0);
+
+    } else {
+        printf("razerkraken: Static mode only accepts RGB (3byte) or RGB with intensity (4byte)\n");
+    }
+
+    return count;
+}
+
+/**
+ * Write device file "mode_custom"
+ *
+ * Custom effect mode is activated whenever the file is written to with 3 bytes
+ */
+ssize_t razer_kraken_attr_write_mode_custom(IOUSBDeviceInterface **dev, const char *buf, size_t count)
+{
+    struct razer_kraken_device device = get_kraken_device(dev);
+    struct razer_kraken_request_report rgb_report = get_kraken_request_report(0x04, 0x40, count, device.custom_address);
+    struct razer_kraken_request_report effect_report = get_kraken_request_report(0x04, 0x40, 0x01, device.led_mode_address);
+    union razer_kraken_effect_byte effect_byte = get_kraken_effect_byte();
+
+    if(count == 3 || count == 4) {
+
+        rgb_report.arguments[0] = buf[0];
+        rgb_report.arguments[1] = buf[1];
+        rgb_report.arguments[2] = buf[2];
+
+        if(count == 4) {
+            rgb_report.arguments[3] = buf[3];
+        }
+
+        // ON/Static
+        effect_byte.bits.on_off_static = 1;
+        effect_report.arguments[0] = 1; //effect_byte.value;
+
+        // Lock sending of the 2 commands
+        razer_kraken_send_control_msg(dev, &rgb_report, 1);
+        razer_kraken_send_control_msg(dev, &effect_report, 1);
+
+    } else {
+        printf("razerkraken: Custom mode only accepts RGB (3byte) or RGB with intensity (4byte)\n");
+    }
+
+    return count;
+}
+
+
+/**
+ * Write device file "mode_breath"
+ *
+ * Breathing effect mode is activated whenever the file is written to with 3,6 or 9 bytes
+ */
+ssize_t razer_kraken_attr_write_mode_breath(IOUSBDeviceInterface **dev, const char *buf, size_t count)
+{
+    struct razer_kraken_device device = get_kraken_device(dev);
+    struct razer_kraken_request_report effect_report = get_kraken_request_report(0x04, 0x40, 0x01, device.led_mode_address);
+    union razer_kraken_effect_byte effect_byte = get_kraken_effect_byte();
+
+    // Short circuit here as rainie only does breathing1
+    if(device.usb_pid == USB_DEVICE_ID_RAZER_KRAKEN && count != 3) {
+        printf("razerkraken: Breathing mode only accepts RGB (3byte)\n");
+        return count;
+    }
+
+    if(count == 3) {
+        struct razer_kraken_request_report rgb_report = get_kraken_request_report(0x04, 0x40, 0x03, device.breathing_address[0]);
+
+        rgb_report.arguments[0] = buf[0];
+        rgb_report.arguments[1] = buf[1];
+        rgb_report.arguments[2] = buf[2];
+
+        // ON/Static
+        effect_byte.bits.on_off_static = 1;
+        effect_byte.bits.single_colour_breathing = 1;
+        effect_byte.bits.sync = 1;
+        effect_report.arguments[0] = effect_byte.value;
+
+        // Lock sending of the 2 commands
+        razer_kraken_send_control_msg(dev, &rgb_report, 0);
+
+        razer_kraken_send_control_msg(dev, &effect_report, 0);
+    } else if(count == 6) {
+        struct razer_kraken_request_report rgb_report  = get_kraken_request_report(0x04, 0x40, 0x03, device.breathing_address[1]);
+        struct razer_kraken_request_report rgb_report2 = get_kraken_request_report(0x04, 0x40, 0x03, device.breathing_address[1]+4); // Address the 2nd set of colours
+
+        rgb_report.arguments[0] = buf[0];
+        rgb_report.arguments[1] = buf[1];
+        rgb_report.arguments[2] = buf[2];
+        rgb_report2.arguments[0] = buf[3];
+        rgb_report2.arguments[1] = buf[4];
+        rgb_report2.arguments[2] = buf[5];
+
+        // ON/Static
+        effect_byte.bits.on_off_static = 1;
+        effect_byte.bits.two_colour_breathing = 1;
+        effect_byte.bits.sync = 1;
+        effect_report.arguments[0] = effect_byte.value;
+
+        // Lock sending of the 2 commands
+        razer_kraken_send_control_msg(dev, &rgb_report, 0);
+
+        razer_kraken_send_control_msg(dev, &rgb_report2, 0);
+
+        razer_kraken_send_control_msg(dev, &effect_report, 0);
+
+    } else if(count == 9) {
+        struct razer_kraken_request_report rgb_report  = get_kraken_request_report(0x04, 0x40, 0x03, device.breathing_address[2]);
+        struct razer_kraken_request_report rgb_report2 = get_kraken_request_report(0x04, 0x40, 0x03, device.breathing_address[2]+4); // Address the 2nd set of colours
+        struct razer_kraken_request_report rgb_report3 = get_kraken_request_report(0x04, 0x40, 0x03, device.breathing_address[2]+8); // Address the 3rd set of colours
+
+        rgb_report.arguments[0] = buf[0];
+        rgb_report.arguments[1] = buf[1];
+        rgb_report.arguments[2] = buf[2];
+        rgb_report2.arguments[0] = buf[3];
+        rgb_report2.arguments[1] = buf[4];
+        rgb_report2.arguments[2] = buf[5];
+        rgb_report3.arguments[0] = buf[6];
+        rgb_report3.arguments[1] = buf[7];
+        rgb_report3.arguments[2] = buf[8];
+
+        // ON/Static
+        effect_byte.bits.on_off_static = 1;
+        effect_byte.bits.three_colour_breathing = 1;
+        effect_byte.bits.sync = 1;
+        effect_report.arguments[0] = effect_byte.value;
+
+        // Lock sending of the 2 commands
+        razer_kraken_send_control_msg(dev, &rgb_report, 0);
+
+        razer_kraken_send_control_msg(dev, &rgb_report2, 0);
+
+        razer_kraken_send_control_msg(dev, &rgb_report3, 0);
+
+        razer_kraken_send_control_msg(dev, &effect_report, 0);
+
+    } else {
+        printf("razerkraken: Breathing mode only accepts RGB (3byte), RGB RGB (6byte) or RGB RGB RGB (9byte)\n");
+    }
+
+    return count;
+}

--- a/src/driver/razerkraken_driver.h
+++ b/src/driver/razerkraken_driver.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2015 Terry Cain <terrys-home.co.uk>
+ */
+
+/*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ */
+
+#include <IOKit/IOKitLib.h>
+#include <IOKit/usb/IOUSBLib.h>
+
+#ifndef __HID_RAZER_KRAKEN_H
+#define __HID_RAZER_KRAKEN_H
+
+
+#define USB_DEVICE_ID_RAZER_KRAKEN_CLASSIC 0x0501
+// Codename Rainie
+#define USB_DEVICE_ID_RAZER_KRAKEN 0x0504
+// Codename Unknown
+#define USB_DEVICE_ID_RAZER_KRAKEN_CLASSIC_ALT 0x0506
+// Codename Kylie
+#define USB_DEVICE_ID_RAZER_KRAKEN_V2 0x0510
+// Codename Unknown
+#define USB_DEVICE_ID_RAZER_KRAKEN_ULTIMATE 0x0527
+
+#define USB_INTERFACE_PROTOCOL_NONE 0
+
+// #define RAZER_KRAKEN_V2_REPORT_LEN ?
+
+struct razer_kraken_device {
+    unsigned char usb_interface_protocol;
+    unsigned short usb_pid;
+    unsigned short usb_vid;
+
+    // Will be set with the correct address for setting LED mode for each device
+    unsigned short led_mode_address;
+    unsigned short custom_address;
+    unsigned short breathing_address[3];
+
+    char serial[23];
+    // 3 Bytes, first byte is whether fw version is collected, 2nd byte is major version, 3rd is minor, should be printed out in hex form as are bcd
+    unsigned char firmware_version[3];
+
+    char data[33];
+
+};
+
+union razer_kraken_effect_byte {
+    unsigned char value;
+    struct razer_kraken_effect_byte_bits {
+        unsigned char on_off_static :1;
+        unsigned char single_colour_breathing :1;
+        unsigned char spectrum_cycling :1;
+        unsigned char sync :1;
+        unsigned char two_colour_breathing :1;
+        unsigned char three_colour_breathing :1;
+    } bits;
+};
+
+/*
+ * Should wait 15ms per write to EEPROM
+ *
+ * Report ID:
+ *   0x04 - Output ID for memory access
+ *   0x05 - Input ID for memory access result
+ *
+ * Destination:
+ *   0x20 - Read data from EEPROM
+ *   0x40 - Write data to RAM
+ *   0x00 - Read data from RAM
+ *
+ * Address:
+ *   RAM - Both
+ *   0x1189 - Custom effect Colour1 Red
+ *   0x118A - Custom effect Colour1 Green
+ *   0x118B - Custom effect Colour1 Blue
+ *   0x118C - Custom effect Colour1 Intensity
+ *
+ *   RAM - Kylie
+ *   0x172D - Set LED Effect, see note 1
+ *   0x1741 - Static/Breathing1 Colour1 Red
+ *   0x1742 - Static/Breathing1 Colour1 Green
+ *   0x1743 - Static/Breathing1 Colour1 Blue
+ *   0x1744 - Static/Breathing1 Colour1 Intensity
+ *
+ *   0x1745 - Breathing2 Colour1 Red
+ *   0x1746 - Breathing2 Colour1 Green
+ *   0x1747 - Breathing2 Colour1 Blue
+ *   0x1748 - Breathing2 Colour1 Intensity
+ *   0x1749 - Breathing2 Colour2 Red
+ *   0x174A - Breathing2 Colour2 Green
+ *   0x174B - Breathing2 Colour2 Blue
+ *   0x174C - Breathing2 Colour2 Intensity
+ *
+ *   0x174D - Breathing3 Colour1 Red
+ *   0x174E - Breathing3 Colour1 Green
+ *   0x174F - Breathing3 Colour1 Blue
+ *   0x1750 - Breathing3 Colour1 Intensity
+ *   0x1751 - Breathing3 Colour2 Red
+ *   0x1752 - Breathing3 Colour2 Green
+ *   0x1753 - Breathing3 Colour2 Blue
+ *   0x1754 - Breathing3 Colour2 Intensity
+ *   0x1755 - Breathing3 Colour3 Red
+ *   0x1756 - Breathing3 Colour3 Green
+ *   0x1757 - Breathing3 Colour3 Blue
+ *   0x1758 - Breathing3 Colour3 Intensity
+ *
+ *   RAM - Rainie
+ *   0x1008 - Set LED Effect, see note 1
+ *   0x15DE - Static/Breathing1 Colour1 Red
+ *   0x15DF - Static/Breathing1 Colour1 Green
+ *   0x15E0 - Static/Breathing1 Colour1 Blue
+ *   0x15E1 - Static/Breathing1 Colour1 Intensity
+ *
+ *   EEPROM
+ *   0x0030 - Firmware version, 2 byted BCD
+ *   0x7f00 - Serial Number - 22 Bytes
+ *
+ *
+ * Note 1:
+ *   Takes one byte which is a bitfield (0 being the rightmost byte 76543210)
+ *     - Bit 0 = LED ON/OFF = 1/0 Static
+ *     - Bit 1 = Single Colour Breathing ON/OFF, 1/0
+ *     - Bit 2 = Spectrum Cycling
+ *     - Bit 3 = Sync = 1
+ *     - Bit 4 = 2 Colour breathing ON/OFF = 1/0
+ *     - Bit 5 = 3 Colour breathing ON/OFF = 1/0
+ *   E.g.
+ *    7   6  5  4  3  2  1  0
+ *    128 64 32 16 8  4  2  1
+ *    =====================================================
+ *    0   0  0  0  0  1  0  1 0x05 Spectrum Cycling on
+ *
+ * Note 2:
+ *   Razer Kraken Classic uses 0x1008 for Logo LED on off.
+ * */
+
+#define KYLIE_SET_LED_ADDRESS 0x172D
+#define RAINIE_SET_LED_ADDRESS 0x1008
+
+#define KYLIE_CUSTOM_ADDRESS_START 0x1189
+#define RAINIE_CUSTOM_ADDRESS_START 0x1189
+
+#define KYLIE_BREATHING1_ADDRESS_START 0x1741
+#define RAINIE_BREATHING1_ADDRESS_START 0x15DE
+
+#define KYLIE_BREATHING2_ADDRESS_START 0x1745
+#define KYLIE_BREATHING3_ADDRESS_START 0x174D
+
+
+struct razer_kraken_request_report {
+    unsigned char report_id;
+    unsigned char destination;
+    unsigned char length;
+    unsigned char addr_h;
+    unsigned char addr_l;
+    unsigned char arguments[32];
+};
+
+struct razer_kraken_response_report {
+    unsigned char report_id;
+    unsigned char arguments[36];
+};
+
+
+
+ssize_t razer_kraken_attr_write_mode_none(IOUSBDeviceInterface **dev, const char *buf, size_t count);
+ssize_t razer_kraken_attr_write_mode_static(IOUSBDeviceInterface **dev, const char *buf, size_t count);
+ssize_t razer_kraken_attr_write_mode_custom(IOUSBDeviceInterface **dev, const char *buf, size_t count);
+ssize_t razer_kraken_attr_write_mode_breath(IOUSBDeviceInterface **dev, const char *buf, size_t count);
+ssize_t razer_kraken_attr_write_mode_spectrum(IOUSBDeviceInterface **dev, const char *buf, size_t count);
+
+#endif

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -892,6 +892,10 @@ let headphoneMenu = [
     ]
   },
   {
+    label: 'Spectrum',
+    click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeSpectrum(); },
+  },
+  {
     label: 'Breathe',
     click() { clearInterval(cycleColorsInterval); addon.headphoneSetModeBreathe(new Uint8Array([
       0 // random


### PR DESCRIPTION
Added kraken_driver from openrazer
- removed linux driver specifics
- changed code to work with IOUSBDeviceInterface
- headphone_driver simply "wraps" the Kraken calls
Added support for Razer Kraken V2 headset
- tested with my own headset on macOS High Sierra (10.13.6)