### PR TITLE
Fixes color settings for Razer Abyssus V2

### DIFF
--- a/src/driver/addon.cc
+++ b/src/driver/addon.cc
@@ -295,18 +295,22 @@ void MouseSetLogoLEDEffect(const Napi::CallbackInfo &info)
   if (std::strncmp(effect, "static", 6) == 0)
   {
     razer_attr_write_logo_led_effect(mouseDev, "0", 1);
+    razer_attr_write_scroll_led_effect(mouseDev, "0", 1);
   }
   else if (std::strncmp(effect, "blinking", 8) == 0)
   {
     razer_attr_write_logo_led_effect(mouseDev, "1", 1);
+    razer_attr_write_scroll_led_effect(mouseDev, "1", 1);
   }
   else if (std::strncmp(effect, "pulsate", 7) == 0)
   {
     razer_attr_write_logo_led_effect(mouseDev, "2", 1);
+    razer_attr_write_scroll_led_effect(mouseDev, "2", 1);
   }
   else if (std::strncmp(effect, "scroll", 6) == 0)
   {
     razer_attr_write_logo_led_effect(mouseDev, "4", 1);
+    razer_attr_write_scroll_led_effect(mouseDev, "4", 1);
   }
 }
 

--- a/src/driver/razermouse_driver.c
+++ b/src/driver/razermouse_driver.c
@@ -777,7 +777,10 @@ ssize_t razer_attr_write_logo_mode_static(IOUSBDeviceInterface **usb_dev, const 
             report = razer_chroma_extended_matrix_effect_static(VARSTORE, LOGO_LED, (struct razer_rgb*)&buf[0]);
             report.transaction_id.id = 0x1f;
             break;
-
+        case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+            report = razer_chroma_standard_set_led_rgb(VARSTORE, LOGO_LED, (struct razer_rgb*)&buf[0]);
+            report.transaction_id.id = 0x3F;
+            break;
         default:
             printf("razermouse: logo_mode_static not supported for this model\n");
             return count;
@@ -837,6 +840,10 @@ ssize_t razer_attr_write_scroll_mode_static(IOUSBDeviceInterface **usb_dev, cons
             case USB_DEVICE_ID_RAZER_BASILISK_V2:
                 report = razer_chroma_extended_matrix_effect_static(VARSTORE, SCROLL_WHEEL_LED, (struct razer_rgb*)&buf[0]);
                 report.transaction_id.id = 0x1f;
+                break;
+            case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+                report = razer_chroma_standard_set_led_rgb(VARSTORE, SCROLL_WHEEL_LED, (struct razer_rgb*)&buf[0]);
+                report.transaction_id.id = 0x3F;
                 break;
 
             default:
@@ -922,6 +929,10 @@ ssize_t razer_attr_write_logo_mode_static_no_store(IOUSBDeviceInterface **usb_de
             report = razer_chroma_extended_matrix_effect_static(NOSTORE, LOGO_LED, (struct razer_rgb*)&buf[0]);
             report.transaction_id.id = 0x1f;
             break;
+        case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+            report = razer_chroma_standard_set_led_rgb(NOSTORE, LOGO_LED, (struct razer_rgb*)&buf[0]);
+            report.transaction_id.id = 0x1f;
+            break;
 
         default:
             printf("razermouse: logo_mode_static not supported for this model\n");
@@ -984,6 +995,10 @@ ssize_t razer_attr_write_scroll_mode_static_no_store(IOUSBDeviceInterface **usb_
             case USB_DEVICE_ID_RAZER_BASILISK_V2:
                 report = razer_chroma_extended_matrix_effect_static(NOSTORE, SCROLL_WHEEL_LED, (struct razer_rgb*)&buf[0]);
                 report.transaction_id.id = 0x1f;
+                break;
+            case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+                report = razer_chroma_standard_set_led_rgb(NOSTORE, SCROLL_WHEEL_LED, (struct razer_rgb*)&buf[0]);
+                report.transaction_id.id = 0x3F;
                 break;
 
             default:
@@ -1381,6 +1396,7 @@ ssize_t razer_attr_write_logo_mode_none(IOUSBDeviceInterface **usb_dev, const ch
         report.transaction_id.id = 0x1f;
         break;
 
+
     default:
         printf("razermouse: logo_mode_none not supported for this model\n");
         return count;
@@ -1467,6 +1483,20 @@ ssize_t razer_attr_write_right_mode_none(IOUSBDeviceInterface **usb_dev, const c
 }
 
 // These are for older mice, eg DeathAdder 2013
+
+/**
+ * Write device file "scroll_led_effect"
+ */
+ssize_t razer_attr_write_scroll_led_effect(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+    unsigned char effect = (unsigned char)strtoul(buf, NULL, 10);
+    struct razer_report report = razer_chroma_standard_set_led_effect(VARSTORE, SCROLL_WHEEL_LED, effect);
+    report.transaction_id.id = 0x3F;
+
+    razer_send_payload(usb_dev, &report);
+
+    return count;
+}
 
 /**
  * Write device file "logo_led_effect"

--- a/src/driver/razermouse_driver.h
+++ b/src/driver/razermouse_driver.h
@@ -160,6 +160,7 @@ void razer_attr_write_dpi(IOUSBDeviceInterface **usb_dev, ushort dpi_x, ushort d
 
 // Older mouse
 ssize_t razer_attr_write_logo_led_effect(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
+ssize_t razer_attr_write_scroll_led_effect(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
 ssize_t razer_attr_write_logo_led_rgb(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
 
 ssize_t razer_attr_read_get_battery(IOUSBDeviceInterface **usb_dev, char *buf);


### PR DESCRIPTION
- Wire up color changes
- Added wheel LED to "Older model effects"

Note: Razer Abyssus V2 has no RED light (hardware). The color channel might be there but all red values are ignored.