### PR TITLE
Wave speed control added for Keyboards

### DIFF
--- a/src/driver/addon.cc
+++ b/src/driver/addon.cc
@@ -101,31 +101,31 @@ void KbdSetModeWave(const Napi::CallbackInfo &info)
     razer_attr_write_mode_wave(kbdDev, "1", 0, 0x10);
   }
 // right
-  else if (std::strncmp(wave_setting,"right_slowest", 12) == 0)
+  else if (std::strncmp(wave_setting,"right_slowest", 13) == 0)
   {
     razer_attr_write_mode_wave(kbdDev, "2", 0, 0x90);
   }
-  else if (std::strncmp(wave_setting,"right_slower", 12) == 0)
+  else if (std::strncmp(wave_setting,"right_slower", 13) == 0)
   {
     razer_attr_write_mode_wave(kbdDev, "2", 0, 0x80);
   }
-  else if (std::strncmp(wave_setting,"right_slow", 12) == 0)
+  else if (std::strncmp(wave_setting,"right_slow", 13) == 0)
   {
     razer_attr_write_mode_wave(kbdDev, "2", 0, 0x70);
   }
-  else if (std::strncmp(wave_setting,"right_default", 12) == 0)
+  else if (std::strncmp(wave_setting,"right_default", 13) == 0)
   {
     razer_attr_write_mode_wave(kbdDev, "2", 0, 0x55);
   }
-  else if (std::strncmp(wave_setting,"right_fast", 12) == 0)
+  else if (std::strncmp(wave_setting,"right_fast", 13) == 0)
   {
     razer_attr_write_mode_wave(kbdDev, "2", 0, 0x40);
   }
-  else if (std::strncmp(wave_setting,"right_faster", 12) == 0)
+  else if (std::strncmp(wave_setting,"right_faster", 13) == 0)
   {
     razer_attr_write_mode_wave(kbdDev, "2", 0, 0x25);
   }
-  else if (std::strncmp(wave_setting,"right_fastest", 12) == 0)
+  else if (std::strncmp(wave_setting,"right_fastest", 13) == 0)
   {
     razer_attr_write_mode_wave(kbdDev, "2", 0, 0x10);
   }

--- a/src/driver/addon.cc
+++ b/src/driver/addon.cc
@@ -71,13 +71,63 @@ void KbdSetModeWave(const Napi::CallbackInfo &info)
   {
     return;
   }
-  if (std::strncmp(info[0].ToString().Utf8Value().c_str(), "left", 4) == 0)
+  const char *wave_setting = info[0].ToString().Utf8Value().c_str();
+  if (std::strncmp(wave_setting,"left_slowest", 12) == 0)
   {
-    razer_attr_write_mode_wave(kbdDev, "1", 0);
+    razer_attr_write_mode_wave(kbdDev, "1", 0, 0x90);
   }
-  else
+  else if (std::strncmp(wave_setting,"left_slower", 12) == 0)
   {
-    razer_attr_write_mode_wave(kbdDev, "2", 0);
+    razer_attr_write_mode_wave(kbdDev, "1", 0, 0x80);
+  }
+  else if (std::strncmp(wave_setting,"left_slow", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "1", 0, 0x70);
+  }
+  else if (std::strncmp(wave_setting,"left_default", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "1", 0, 0x55);
+  }
+  else if (std::strncmp(wave_setting,"left_fast", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "1", 0, 0x40);
+  }
+  else if (std::strncmp(wave_setting,"left_faster", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "1", 0, 0x25);
+  }
+  else if (std::strncmp(wave_setting,"left_fastest", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "1", 0, 0x10);
+  }
+// right
+  else if (std::strncmp(wave_setting,"right_slowest", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "2", 0, 0x90);
+  }
+  else if (std::strncmp(wave_setting,"right_slower", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "2", 0, 0x80);
+  }
+  else if (std::strncmp(wave_setting,"right_slow", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "2", 0, 0x70);
+  }
+  else if (std::strncmp(wave_setting,"right_default", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "2", 0, 0x55);
+  }
+  else if (std::strncmp(wave_setting,"right_fast", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "2", 0, 0x40);
+  }
+  else if (std::strncmp(wave_setting,"right_faster", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "2", 0, 0x25);
+  }
+  else if (std::strncmp(wave_setting,"right_fastest", 12) == 0)
+  {
+    razer_attr_write_mode_wave(kbdDev, "2", 0, 0x10);
   }
 }
 

--- a/src/driver/razerchromacommon.c
+++ b/src/driver/razerchromacommon.c
@@ -542,7 +542,7 @@ struct razer_report razer_chroma_extended_matrix_effect_static(unsigned char var
  * 00     3f    0000   00    06       0f    02  010504002800 | SET LED MATRIX Effect (VARSTR, Backlight, Wave 0x04, Dir 0x00, ? 0x2800)
  * 00     3f    0000   00    06       0f    02  010504012800 | SET LED MATRIX Effect (VARSTR, Backlight, Wave 0x04, Dir 0x01, ? 0x2800)
  */
-struct razer_report razer_chroma_extended_matrix_effect_wave(unsigned char variable_storage, unsigned char led_id, unsigned char direction)
+struct razer_report razer_chroma_extended_matrix_effect_wave(unsigned char variable_storage, unsigned char led_id, unsigned char direction, int speed)
 {
     struct razer_report report = razer_chroma_extended_matrix_effect_base(0x06, variable_storage, led_id, 0x04);
 
@@ -551,7 +551,7 @@ struct razer_report razer_chroma_extended_matrix_effect_wave(unsigned char varia
     direction = clamp_u8(direction, 0x00, 0x02);
 
     report.arguments[3] = direction;
-    report.arguments[4] = 0x28; // Unknown
+    report.arguments[4] = speed; // Speed, lower values are faster (). The default used to be 0x28
     return report;
 }
 

--- a/src/driver/razerchromacommon.h
+++ b/src/driver/razerchromacommon.h
@@ -58,7 +58,7 @@ struct razer_report razer_chroma_standard_matrix_set_custom_frame(unsigned char 
  */
 struct razer_report razer_chroma_extended_matrix_effect_none(unsigned char variable_storage, unsigned char led_id);
 struct razer_report razer_chroma_extended_matrix_effect_static(unsigned char variable_storage, unsigned char led_id, struct razer_rgb *rgb);
-struct razer_report razer_chroma_extended_matrix_effect_wave(unsigned char variable_storage, unsigned char led_id, unsigned char direction);
+struct razer_report razer_chroma_extended_matrix_effect_wave(unsigned char variable_storage, unsigned char led_id, unsigned char direction, int speed);
 struct razer_report razer_chroma_extended_matrix_effect_starlight_random(unsigned char variable_storage, unsigned char led_id, unsigned char speed);
 struct razer_report razer_chroma_extended_matrix_effect_starlight_single(unsigned char variable_storage, unsigned char led_id, unsigned char speed, struct razer_rgb *rgb1);
 struct razer_report razer_chroma_extended_matrix_effect_starlight_dual(unsigned char variable_storage, unsigned char led_id, unsigned char speed, struct razer_rgb *rgb1, struct razer_rgb *rgb2);

--- a/src/driver/razeregpu_driver.c
+++ b/src/driver/razeregpu_driver.c
@@ -152,7 +152,7 @@ ssize_t razer_egpu_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const ch
     switch (product)
     {
     case USB_DEVICE_ID_RAZER_CORE_X_CHROMA:
-        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, ZERO_LED, direction);
+        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, ZERO_LED, direction, 0x28);
         break;
 
     default:

--- a/src/driver/razerkbd_driver.c
+++ b/src/driver/razerkbd_driver.c
@@ -540,7 +540,7 @@ ssize_t razer_attr_write_mode_none(IOUSBDeviceInterface **usb_dev, const char *b
  *
  * For the extended its 0x00 and 0x01
  */
-ssize_t razer_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *buf, int count)
+ssize_t razer_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *buf, int count, int speed)
 {
     unsigned char direction = (unsigned char)strtol(buf, NULL, 10);
     struct razer_report report;
@@ -559,7 +559,7 @@ ssize_t razer_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *b
     case USB_DEVICE_ID_RAZER_HUNTSMAN:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
     case USB_DEVICE_ID_RAZER_CYNOSA_CHROMA:
-        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, BACKLIGHT_LED, direction);
+        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, BACKLIGHT_LED, direction, speed);
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
@@ -570,7 +570,7 @@ ssize_t razer_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *b
     case USB_DEVICE_ID_RAZER_TARTARUS_V2:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ELITE:
     case USB_DEVICE_ID_RAZER_CYNOSA_V2:
-        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, BACKLIGHT_LED, direction);
+        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, BACKLIGHT_LED, direction, speed);
         report.transaction_id.id = 0x1F;
         break;
 

--- a/src/driver/razerkbd_driver.h
+++ b/src/driver/razerkbd_driver.h
@@ -138,7 +138,7 @@ ssize_t razer_attr_read_tartarus_profile_led_green(IOUSBDeviceInterface **usb_de
 ssize_t razer_attr_read_tartarus_profile_led_blue(IOUSBDeviceInterface **usb_dev, char *buf);
 ssize_t razer_attr_read_get_firmware_version(IOUSBDeviceInterface **usb_dev, char *buf);
 ssize_t razer_attr_write_mode_none(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
-ssize_t razer_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
+ssize_t razer_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *buf, int count, int speed);
 ssize_t razer_attr_write_mode_spectrum(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 ssize_t razer_attr_write_mode_reactive(IOUSBDeviceInterface **usb_dev, const char *buf, int count);
 ssize_t razer_attr_write_mode_static(IOUSBDeviceInterface **usb_dev, const char *buf, int count);

--- a/src/driver/razermouse_driver.c
+++ b/src/driver/razermouse_driver.c
@@ -326,12 +326,12 @@ ssize_t razer_attr_write_side_mode_wave(IOUSBDeviceInterface **usb_dev, const ch
         case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
         case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE:
         case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, side, direction);
+            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, side, direction, 0x28);
             break;
 
         case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
         case USB_DEVICE_ID_RAZER_BASILISK_V2:
-            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, side, direction);
+            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, side, direction, 0x28);
             report.transaction_id.id = 0x1f;
             break;
 
@@ -653,12 +653,12 @@ ssize_t razer_attr_write_logo_mode_wave(IOUSBDeviceInterface **usb_dev, const ch
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, LOGO_LED, direction);
+        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, LOGO_LED, direction, 0x28);
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
     case USB_DEVICE_ID_RAZER_BASILISK_V2:
-        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, LOGO_LED, direction);
+        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, LOGO_LED, direction, 0x28);
         report.transaction_id.id = 0x1f;
         break;
 
@@ -692,12 +692,12 @@ ssize_t razer_attr_write_scroll_mode_wave(IOUSBDeviceInterface **usb_dev, const 
         case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
         case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE:
         case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, SCROLL_WHEEL_LED, direction);
+            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, SCROLL_WHEEL_LED, direction, 0x28);
             break;
 
         case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
         case USB_DEVICE_ID_RAZER_BASILISK_V2:
-            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, SCROLL_WHEEL_LED, direction);
+            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, SCROLL_WHEEL_LED, direction, 0x28);
             report.transaction_id.id = 0x1f;
             break;
 

--- a/src/driver/razermousemat_driver.c
+++ b/src/driver/razermousemat_driver.c
@@ -159,7 +159,7 @@ ssize_t razer_mouse_mat_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, con
     switch(product) {
     case USB_DEVICE_ID_RAZER_FIREFLY_V2:
     case USB_DEVICE_ID_RAZER_FIREFLY_HYPERFLUX:
-        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, ZERO_LED, direction);
+        report = razer_chroma_extended_matrix_effect_wave(VARSTORE, ZERO_LED, direction, 0x28);
         break;
 
     default:

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -373,20 +373,116 @@ let keyboardMenu = [
   },
   {
     label: 'Wave',
-    submenu: [
+    submenu:[
       {
         label: 'Left',
-        click() {
-          clearInterval(cycleColorsInterval);
-          addon.kbdSetModeWave('left');
-        },
+        submenu:[
+          {
+            label: 'Slowest Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('left_slowest');
+            },
+          },
+          {
+            label: 'Slower Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('left_slower');
+            },
+          },
+          {
+            label: 'Slow Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('left_slow');
+            },
+          },
+
+          {
+            label: 'Normal Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('left_default');
+            },
+          },
+          {
+            label: 'Fast Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('left_fast');
+            },
+          },
+          {
+            label: 'Faster Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('left_faster');
+            },
+          },
+          {
+            label: 'Lighting Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('left_fastest');
+            },
+          },
+        ]
       },
       {
         label: 'Right',
-        click() {
-          clearInterval(cycleColorsInterval);
-          addon.kbdSetModeWave('right');
-        },
+        submenu:[
+          {
+            label: 'Slowest Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('right_slowest');
+            },
+          },
+          {
+            label: 'Slower Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('right_slower');
+            },
+          },
+          {
+            label: 'Slow Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('right_slow');
+            },
+          },
+
+          {
+            label: 'Normal Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('right_default');
+            },
+          },
+          {
+            label: 'Fast Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('right_fast');
+            },
+          },
+          {
+            label: 'Faster Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('right_faster');
+            },
+          },
+          {
+            label: 'Lighting Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.kbdSetModeWave('right_fastest');
+            },
+          }, 
+        ]
       },
     ],
   },


### PR DESCRIPTION
I saw an issue #130 and I fixed it. It only works on these following keyboards
RAZER_ORNATA
RAZER_ORNATA_CHROMA
RAZER_ORNATA_V2
RAZER_HUNTSMAN_ELITE
RAZER_HUNTSMAN_TE
RAZER_BLACKWIDOW_2019
RAZER_HUNTSMAN
RAZER_BLACKWIDOW_ESSENTIAL
RAZER_CYNOSA_CHROMA
RAZER_TARTARUS_V2
RAZER_BLACKWIDOW_ELITE
RAZER_CYNOSA_V2


I did so by adding a speed parameter to razer_attr_write_mode_wave functions and any other required changes