### PR TITLE
Added razer accessory driver from openrazer project

### DIFF
--- a/src/driver/addon.cc
+++ b/src/driver/addon.cc
@@ -18,6 +18,7 @@ IOUSBDeviceInterface **mouseDockDev;
 IOUSBDeviceInterface **mouseMatDev;
 IOUSBDeviceInterface **egpuDev;
 IOUSBDeviceInterface **headphoneDev;
+IOUSBDeviceInterface **accDev;
 
 /**
 * Get the Razer Keyboard USB device interface and device name, 
@@ -1007,6 +1008,230 @@ void HeadphoneSetModeSpectrum(const Napi::CallbackInfo &info)
     razer_headphone_attr_write_mode_spectrum(headphoneDev, "1", 1);
 }
 
+/**
+* Get the Razer Accessory USB device interface and device name,
+* return JS Null if non found
+*/
+Napi::Value GetAccessoryDevice(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+
+    accDev = getRazerUSBDeviceInterface(TYPE_ACCESSORY);
+    if (accDev == NULL)
+    {
+        return env.Null();
+    }
+
+    char buf[256] = {0};
+    razer_accessory_attr_read_device_type(accDev, buf);
+    return Napi::String::New(env, buf);
+}
+
+void CloseAccessoryDevice(const Napi::CallbackInfo &info)
+{
+    if (accDev == NULL)
+    {
+        return;
+    }
+    closeRazerUSBDeviceInterface(accDev);
+}
+
+void AccessorySetModeNone(const Napi::CallbackInfo &info)
+{
+    if (accDev == NULL)
+    {
+        return;
+    }
+    razer_accessory_attr_write_mode_none(accDev, "1", 1);
+}
+
+void AccessorySetModeSpectrum(const Napi::CallbackInfo &info)
+{
+    if (accDev == NULL)
+    {
+        return;
+    }
+    razer_accessory_attr_write_mode_spectrum(accDev, "1", 1);
+}
+
+void AccessorySetModeWave(const Napi::CallbackInfo &info)
+{
+    if (accDev == NULL)
+    {
+        return;
+    }
+    std::string waveSettingString = info[0].ToString().Utf8Value();
+    const char* waveSetting = waveSettingString.c_str();
+    if (std::strncmp(waveSetting,"left_turtle", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0xFF);
+    }
+    else if (std::strncmp(waveSetting,"left_slowest", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0xD9);
+    }
+    else if (std::strncmp(waveSetting,"left_slower", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0xB9);
+    }
+    else if (std::strncmp(waveSetting,"left_slow", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0x90);
+    }
+    else if (std::strncmp(waveSetting,"left_default", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0x70);
+    }
+    else if (std::strncmp(waveSetting,"left_fast", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0x55);
+    }
+    else if (std::strncmp(waveSetting,"left_faster", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0x40);
+    }
+    else if (std::strncmp(waveSetting,"left_fastest", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0x25);
+    }
+    else if (std::strncmp(waveSetting,"left_lightning", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "1", 0, 0x10);
+    }
+// right
+    else if (std::strncmp(waveSetting,"right_turtle", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0xFF);
+    }
+    else if (std::strncmp(waveSetting,"right_slowest", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0xD9);
+    }
+    else if (std::strncmp(waveSetting,"right_slower", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0xB9);
+    }
+    else if (std::strncmp(waveSetting,"right_slow", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0x90);
+    }
+    else if (std::strncmp(waveSetting,"right_default", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0x70);
+    }
+    else if (std::strncmp(waveSetting,"right_fast", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0x55);
+    }
+    else if (std::strncmp(waveSetting,"right_faster", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0x40);
+    }
+    else if (std::strncmp(waveSetting,"right_fastest", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0x25);
+    }
+    else if (std::strncmp(waveSetting,"right_lightning", 20) == 0)
+    {
+        razer_accessory_attr_write_mode_wave(accDev, "2", 0, 0x10);
+    }
+}
+
+void AccessorySetModeStatic(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+    if (accDev == NULL)
+    {
+        return;
+    }
+
+    Napi::Uint8Array argsArr = info[0].As<Napi::Uint8Array>();
+
+    if (argsArr.ElementLength() != 3)
+    {
+        Napi::TypeError::New(env, "Static only accepts RGB (3byte).")
+                .ThrowAsJavaScriptException();
+        return;
+    }
+    // Cast unsigned char array into char array
+    char *buf = (char *)info[0].As<Napi::Uint8Array>().Data();
+
+    razer_accessory_attr_write_mode_static(accDev, buf, 3);
+}
+
+void AccessorySetModeStaticNoStore(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+    if (accDev == NULL)
+    {
+        return;
+    }
+
+    Napi::Uint8Array argsArr = info[0].As<Napi::Uint8Array>();
+
+    if (argsArr.ElementLength() != 3)
+    {
+        Napi::TypeError::New(env, "Static only accepts RGB (3byte).")
+                .ThrowAsJavaScriptException();
+        return;
+    }
+    // Cast unsigned char array into char array
+    char *buf = (char *)info[0].As<Napi::Uint8Array>().Data();
+
+    // we don't have no store
+    razer_accessory_attr_write_mode_static(accDev, buf, 3);
+}
+
+void AccessorySetModeBreathe(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+    if (kbdDev == NULL)
+    {
+        return;
+    }
+
+    Napi::Uint8Array argsArr = info[0].As<Napi::Uint8Array>();
+
+    if (argsArr.ElementLength() != 1)
+    {
+        Napi::TypeError::New(env, "Breathing only accepts '1' (1byte). RGB (3byte). RGB, RGB (6byte)")
+                .ThrowAsJavaScriptException();
+        return;
+    }
+    // Cast unsigned char array into char array
+    char *buf = (char *)info[0].As<Napi::Uint8Array>().Data();
+
+    razer_accessory_attr_write_mode_breath(accDev, buf, 1);
+}
+Napi::Number AccessoryGetBrightness(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+
+    // Return -1 if no device
+    if (accDev == NULL)
+    {
+        return Napi::Number::New(env, -1);
+    }
+
+    ushort brightness = razer_accessory_attr_read_set_brightness(accDev);
+
+    return Napi::Number::New(env, brightness);
+}
+
+void AccessorySetBrightness(const Napi::CallbackInfo &info)
+{
+    if (accDev == NULL)
+    {
+        return;
+    }
+
+    Napi::Number brightness_number = info[0].ToNumber();
+
+    ushort brightness = brightness_number.Int32Value();
+
+    razer_accessory_attr_write_set_brightness(accDev, brightness, 1);
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("getKeyboardDevice", Napi::Function::New(env, GetKeyboardDevice));
   exports.Set("closeKeyboardDevice", Napi::Function::New(env, CloseKeyboardDevice));
@@ -1075,6 +1300,18 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("headphoneSetModeStatic", Napi::Function::New(env, HeadphoneSetModeStatic));
   exports.Set("headphoneSetModeStaticNoStore", Napi::Function::New(env, HeadphoneSetModeStaticNoStore));
   exports.Set("headphoneSetModeSpectrum", Napi::Function::New(env, HeadphoneSetModeSpectrum));
+
+  // Accessory
+  exports.Set("getAccessoryDevice", Napi::Function::New(env, GetAccessoryDevice));
+  exports.Set("closeAccessoryDevice", Napi::Function::New(env, CloseAccessoryDevice));
+  exports.Set("accessorySetModeNone", Napi::Function::New(env, AccessorySetModeNone));
+  exports.Set("accessorySetModeSpectrum", Napi::Function::New(env, AccessorySetModeSpectrum));
+  exports.Set("accessorySetModeStatic", Napi::Function::New(env, AccessorySetModeStatic));
+  exports.Set("accessorySetModeStaticNoStore", Napi::Function::New(env, AccessorySetModeStaticNoStore));
+  exports.Set("accessorySetModeWave", Napi::Function::New(env, AccessorySetModeWave));
+  exports.Set("accessorySetModeBreathe", Napi::Function::New(env, AccessorySetModeBreathe));
+  exports.Set("accessoryGetBrightness", Napi::Function::New(env, AccessoryGetBrightness));
+  exports.Set("accessorySetBrightness", Napi::Function::New(env, AccessorySetBrightness));
 
   return exports;
 }

--- a/src/driver/razeraccessory_driver.c
+++ b/src/driver/razeraccessory_driver.c
@@ -1,0 +1,571 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Should you need to contact me, the author, you can do so by
+ * e-mail - mail your message to Terry Cain <terry@terrys-home.co.uk>
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "razeraccessory_driver.h"
+#include "razercommon.h"
+#include "razerchromacommon.h"
+
+/**
+ * Send report to the device
+ */
+static int razer_get_report(IOUSBDeviceInterface **usb_dev, struct razer_report *request_report, struct razer_report *response_report)
+{
+    return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_ACCESSORY_WAIT_MIN_US);
+}
+
+/**
+ * Function to send to device, get response, and actually check the response
+ */
+static struct razer_report razer_send_payload(IOUSBDeviceInterface **usb_dev, struct razer_report *request_report)
+{
+    int retval = -1;
+    struct razer_report response_report = {0};
+
+    request_report->crc = razer_calculate_crc(request_report);
+
+    retval = razer_get_report(usb_dev, request_report, &response_report);
+
+    if(retval == 0) {
+        // Check the packet number, class and command are the same
+        if(response_report.remaining_packets != request_report->remaining_packets ||
+           response_report.command_class != request_report->command_class ||
+           response_report.command_id.id != request_report->command_id.id) {
+            //print_erroneous_report(&response_report, "razeraccessory", "Response doesn't match request");
+//        } else if (response_report.status == RAZER_CMD_BUSY) {
+//           // print_erroneous_report(&response_report, "razermouse", "Device is busy");
+        } else if (response_report.status == RAZER_CMD_FAILURE) {
+            //print_erroneous_report(&response_report, "razeraccessory", "Command failed");
+        } else if (response_report.status == RAZER_CMD_NOT_SUPPORTED) {
+            //print_erroneous_report(&response_report, "razeraccessory", "Command not supported");
+        } else if (response_report.status == RAZER_CMD_TIMEOUT) {
+            //print_erroneous_report(&response_report, "razeraccessory", "Command timed out");
+        }
+    } else {
+        //print_erroneous_report(&response_report, "razeraccessory", "Invalid Report Length");
+    }
+
+    return response_report;
+}
+
+
+
+/**
+ * Read device file "device_type"
+ *
+ * Returns friendly string of device type
+ */
+ssize_t razer_accessory_attr_read_device_type(IOUSBDeviceInterface **usb_dev, char *buf)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+
+    char *device_type;
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+            device_type = "Razer Chroma Mug Holder\n";
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+            device_type = "Razer Chroma HDK\n";
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+            device_type = "Razer Base Station Chroma\n";
+            break;
+
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            device_type = "Razer Base Station V2 Chroma\n";
+            break;
+
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+            device_type = "Razer Nommo Pro\n";
+            break;
+
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+            device_type = "Razer Nommo Chroma\n";
+            break;
+
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+            device_type = "Razer Mouse Bungee V3 Chroma\n";
+            break;
+
+        default:
+            device_type = "Unknown Device\n";
+            break;
+    }
+
+    return sprintf(buf, "%s", device_type);
+}
+
+
+
+/**
+ * Write device file "mode_spectrum"
+ *
+ * Specrum effect mode is activated whenever the file is written to
+ */
+ssize_t razer_accessory_attr_write_mode_spectrum(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = { 0 };
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+            report = razer_chroma_standard_matrix_effect_spectrum(VARSTORE, BACKLIGHT_LED);
+            report.transaction_id.id = 0x3F;
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+            report = razer_chroma_extended_matrix_effect_spectrum(VARSTORE, ZERO_LED);
+            report.transaction_id.id = 0x3F;
+            break;
+
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            report = razer_chroma_extended_matrix_effect_spectrum(VARSTORE, ZERO_LED);
+            report.transaction_id.id = 0x1F;
+            break;
+
+        default:
+            printf("razeraccessory: Unknown device\n");
+            break;
+    }
+
+    razer_send_payload(usb_dev, &report);
+
+    return count;
+}
+
+/**
+ * Write device file "mode_none"
+ *
+ * None effect mode is activated whenever the file is written to
+ */
+ssize_t razer_accessory_attr_write_mode_none(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = { 0 };
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+            report = razer_chroma_standard_matrix_effect_none(VARSTORE, BACKLIGHT_LED);
+            report.transaction_id.id = 0x3F;
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+            report = razer_chroma_extended_matrix_effect_none(VARSTORE, ZERO_LED);
+            report.transaction_id.id = 0x3F;
+            break;
+
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            report = razer_chroma_extended_matrix_effect_none(VARSTORE, ZERO_LED);
+            report.transaction_id.id = 0x1F;
+            break;
+
+        default:
+            printf("razeraccessory: Unknown device\n");
+            break;
+    }
+
+    razer_send_payload(usb_dev, &report);
+
+    return count;
+}
+
+/**
+ * Write device file "mode_blinking"
+ *
+ * Blinking effect mode is activated whenever the file is written to with 3 bytes
+ */
+ssize_t razer_accessory_attr_write_mode_blinking(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+
+    struct razer_report report_rgb = {0};
+    struct razer_report report_effect = razer_chroma_standard_set_led_effect(VARSTORE, BACKLIGHT_LED, 0x01);
+    report_effect.transaction_id.id = 0x3F;
+
+    if(count == 3) {
+        report_rgb = razer_chroma_standard_set_led_rgb(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
+        report_rgb.transaction_id.id = 0x3F;
+
+        razer_send_payload(usb_dev, &report_rgb);
+        usleep(5 * 1000);
+        razer_send_payload(usb_dev, &report_effect);
+
+    } else {
+        printf("razeraccessory: Blinking mode only accepts RGB (3byte)\n");
+    }
+
+    return count;
+}
+
+/**
+ * Write device file "mode_custom"
+ *
+ * Sets the device to custom mode whenever the file is written to
+ */
+ssize_t razer_accessory_attr_write_mode_custom(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = { 0 };
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+            report = razer_chroma_standard_matrix_effect_custom_frame(NOSTORE);
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+            report = razer_chroma_extended_matrix_effect_custom_frame();
+            break;
+
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            report = razer_chroma_extended_matrix_effect_custom_frame();
+            report.transaction_id.id = 0x1F;
+            break;
+
+        default:
+            printf("razeraccessory: Unknown device\n");
+            break;
+    }
+
+    razer_send_payload(usb_dev, &report);
+
+    return count;
+}
+
+/**
+ * Write device file "mode_static"
+ *
+ * Static effect mode is activated whenever the file is written to with 3 bytes
+ */
+ssize_t razer_accessory_attr_write_mode_static(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = {0};
+
+    if(count == 3) {
+        switch (product) {
+            case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+                report = razer_chroma_standard_matrix_effect_static(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*) & buf[0]);
+                report.transaction_id.id = 0x3F;
+                break;
+
+            case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+            case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+            case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+            case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+                report = razer_chroma_extended_matrix_effect_static(VARSTORE, ZERO_LED, (struct razer_rgb*) & buf[0]);
+                report.transaction_id.id = 0x3F;
+                break;
+
+            case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+            case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+                report = razer_chroma_extended_matrix_effect_static(VARSTORE, ZERO_LED, (struct razer_rgb*) & buf[0]);
+                report.transaction_id.id = 0x1F;
+                break;
+
+            default:
+                printf("razeraccessory: Unknown device\n");
+                break;
+        }
+
+        razer_send_payload(usb_dev, &report);
+
+    } else {
+        printf("razeraccessory: Static mode only accepts RGB (3byte)\n");
+    }
+
+    return count;
+}
+
+/**
+ * Write device file "mode_wave"
+ *
+ * When 1 is written (as a character, 0x31) the wave effect is displayed moving anti clockwise
+ * if 2 is written (0x32) then the wave effect goes clockwise
+ */
+ssize_t razer_accessory_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count, int speed)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    unsigned char direction = (unsigned char)strtol(buf, NULL, 10);
+    struct razer_report report = { 0 };
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+            report = razer_chroma_standard_matrix_effect_wave(VARSTORE, BACKLIGHT_LED, direction);
+            report.transaction_id.id = 0x3F;
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, ZERO_LED, direction, speed);
+            report.transaction_id.id = 0x3F;
+            break;
+
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            report = razer_chroma_extended_matrix_effect_wave(VARSTORE, ZERO_LED, direction, speed);
+            report.transaction_id.id = 0x1F;
+            break;
+
+        default:
+            printf("razeraccessory: Unknown device\n");
+            break;
+    }
+
+    razer_send_payload(usb_dev, &report);
+
+    return count;
+}
+
+/**
+ * Write device file "mode_breath"
+ *
+ * Breathing effect mode is activated whenever the file is written to with 1, 3, or 6 bytes
+ */
+ssize_t razer_accessory_attr_write_mode_breath(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = {0};
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+            switch(count) {
+                case 3: // Single colour mode
+                    report = razer_chroma_extended_matrix_effect_breathing_single(VARSTORE, ZERO_LED, (struct razer_rgb *)&buf[0]);
+                    report.transaction_id.id = 0x3F;
+                    break;
+
+                case 6: // Dual colour mode
+                    report = razer_chroma_extended_matrix_effect_breathing_dual(VARSTORE, ZERO_LED, (struct razer_rgb *)&buf[0], (struct razer_rgb *)&buf[3]);
+                    report.transaction_id.id = 0x3F;
+                    break;
+
+                default: // "Random" colour mode
+                    report = razer_chroma_extended_matrix_effect_breathing_random(VARSTORE, ZERO_LED);
+                    report.transaction_id.id = 0x3F;
+                    break;
+            }
+            break;
+
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            switch(count) {
+                case 3: // Single colour mode
+                    report = razer_chroma_extended_matrix_effect_breathing_single(VARSTORE, ZERO_LED, (struct razer_rgb *)&buf[0]);
+                    report.transaction_id.id = 0x1F;
+                    break;
+
+                case 6: // Dual colour mode
+                    report = razer_chroma_extended_matrix_effect_breathing_dual(VARSTORE, ZERO_LED, (struct razer_rgb *)&buf[0], (struct razer_rgb *)&buf[3]);
+                    report.transaction_id.id = 0x1F;
+                    break;
+
+                default: // "Random" colour mode
+                    report = razer_chroma_extended_matrix_effect_breathing_random(VARSTORE, ZERO_LED);
+                    report.transaction_id.id = 0x1F;
+                    break;
+            }
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+            switch(count) {
+                case 3: // Single colour mode
+                    report = razer_chroma_standard_matrix_effect_breathing_single(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
+                    report.transaction_id.id = 0x3F;
+                    break;
+
+                case 6: // Dual colour mode
+                    report = razer_chroma_standard_matrix_effect_breathing_dual(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
+                    report.transaction_id.id = 0x3F;
+                    break;
+
+                default: // "Random" colour mode
+                    report = razer_chroma_standard_matrix_effect_breathing_random(VARSTORE, BACKLIGHT_LED);
+                    report.transaction_id.id = 0x3F;
+                    break;
+            }
+            break;
+
+        default:
+            printf("razeraccessory: Unknown device\n");
+            break;
+    }
+
+    razer_send_payload(usb_dev, &report);
+
+    return count;
+}
+
+/**
+ * Write device file "device_mode"
+ */
+ssize_t razer_accessory_attr_write_device_mode(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = {0};
+
+    if (count != 2) {
+        printf("razeraccessory: Device mode only takes 2 bytes.");
+    } else {
+
+        report = razer_chroma_standard_set_device_mode(buf[0], buf[1]);
+
+        switch(product) {
+            case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+            case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+                report.transaction_id.id = 0x1F;
+                break;
+        }
+
+        razer_send_payload(usb_dev, &report);
+    }
+
+    return count;
+}
+
+ssize_t razer_accessory_attr_read_get_cup_state(IOUSBDeviceInterface **usb_dev, char *buf)
+{
+    struct razer_report report = get_razer_report(0x02, 0x81, 0x02);
+    struct razer_report response = {0};
+
+    response = razer_send_payload(usb_dev, &report);
+
+    return sprintf(buf, "%u\n", response.arguments[1]);
+}
+
+/**
+ * Read device file "device_mode"
+ *
+ * Returns a string
+ */
+ssize_t razer_accessory_attr_read_device_mode(IOUSBDeviceInterface **usb_dev, char *buf)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = razer_chroma_standard_get_device_mode();
+    struct razer_report response = {0};
+
+    switch(product) {
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            report.transaction_id.id = 0x1F;
+            break;
+    }
+
+    response = razer_send_payload(usb_dev, &report);
+
+    return sprintf(buf, "%d:%d\n", response.arguments[0], response.arguments[1]);
+}
+
+/**
+ * Write device file "set_brightness"
+ *
+ * Sets the brightness to the ASCII number written to this file.
+ */
+ssize_t razer_accessory_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, ushort brightness, size_t count)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = {0};
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            report = razer_chroma_extended_matrix_brightness(VARSTORE, ZERO_LED, brightness);
+            report.transaction_id.id = 0x1F;
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+            report = razer_chroma_standard_set_led_brightness(VARSTORE, BACKLIGHT_LED, brightness);
+            break;
+
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+            report = razer_chroma_extended_matrix_brightness(VARSTORE, ZERO_LED, brightness);
+            break;
+
+        default:
+            printf("razeraccessory: Unknown device\n");
+            break;
+    }
+
+    razer_send_payload(usb_dev, &report);
+
+    return count;
+}
+
+/**
+ * Read device file "set_brightness"
+ *
+ * Returns brightness or -1 if the initial brightness is not known
+ */
+ushort razer_accessory_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+    struct razer_report report = razer_chroma_standard_get_led_brightness(VARSTORE, BACKLIGHT_LED);
+    struct razer_report response = {0};
+    unsigned char brightness = 0;
+
+    switch (product) {
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            break;
+
+        default:
+            response = razer_send_payload(usb_dev, &report);
+            brightness = response.arguments[2];
+            break;
+    }
+
+    return brightness;
+}

--- a/src/driver/razeraccessory_driver.h
+++ b/src/driver/razeraccessory_driver.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2015 Terry Cain <terrys-home.co.uk>
+ */
+
+/*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ */
+
+#include <IOKit/IOKitLib.h>
+#include <IOKit/usb/IOUSBLib.h>
+
+#ifndef __HID_RAZER_ACCESSORY_H
+#define __HID_RAZER_ACCESSORY_H
+
+#define USB_DEVICE_ID_RAZER_NOMMO_CHROMA 0x0517
+#define USB_DEVICE_ID_RAZER_NOMMO_PRO 0x0518
+#define USB_DEVICE_ID_RAZER_CHROMA_MUG 0x0F07
+#define USB_DEVICE_ID_RAZER_CHROMA_BASE 0x0F08
+#define USB_DEVICE_ID_RAZER_CHROMA_HDK 0x0F09
+#define USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA 0x0F1D
+#define USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA 0x0F20
+
+#define RAZER_ACCESSORY_WAIT_MIN_US 600
+#define RAZER_ACCESSORY_WAIT_MAX_US 1000
+
+ssize_t razer_accessory_attr_read_device_type(IOUSBDeviceInterface **usb_dev, char *buf);
+ssize_t razer_accessory_attr_write_mode_none(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
+ssize_t razer_accessory_attr_write_mode_spectrum(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
+ssize_t razer_accessory_attr_write_mode_wave(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count, int speed);
+ssize_t razer_accessory_attr_write_mode_static(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
+ssize_t razer_accessory_attr_write_mode_breath(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
+ushort razer_accessory_attr_read_set_brightness(IOUSBDeviceInterface **usb_dev);
+ssize_t razer_accessory_attr_write_set_brightness(IOUSBDeviceInterface **usb_dev, ushort brightness, size_t count);
+
+
+#endif

--- a/src/driver/razerdevice.c
+++ b/src/driver/razerdevice.c
@@ -189,6 +189,20 @@ bool is_headphone(IOUSBDeviceInterface **usb_dev)
     return false;
 }
 
+bool is_accessory(IOUSBDeviceInterface **usb_dev)
+{
+    UInt16 product = -1;
+    (*usb_dev)->GetDeviceProduct(usb_dev, &product);
+
+    switch (product)
+    {
+        case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+            return true;
+    }
+
+    return false;
+}
+
 IOUSBDeviceInterface **getRazerUSBDeviceInterface(int type)
 {
 	CFMutableDictionaryRef matchingDict;
@@ -294,6 +308,13 @@ IOUSBDeviceInterface **getRazerUSBDeviceInterface(int type)
 				  continue;
 			    }
 			  break;
+            case TYPE_ACCESSORY:
+                if (!is_accessory(dev))
+                {
+                    (*dev)->Release(dev);
+                    continue;
+                }
+                break;
         
 		    default:
 			    // Unsupported Razer peripheral type

--- a/src/driver/razerdevice.h
+++ b/src/driver/razerdevice.h
@@ -15,6 +15,7 @@
 #include "razerheadphone_driver.h"
 #include "razeregpu_driver.h"
 #include "razerkraken_driver.h"
+#include "razeraccessory_driver.h"
 
 #define TYPE_KEYBOARD 0
 #define TYPE_BLADE 1
@@ -23,6 +24,7 @@
 #define TYPE_MOUSE_MAT 4
 #define TYPE_EGPU 5
 #define TYPE_HEADPHONE 6
+#define TYPE_ACCESSORY 7
 
 #ifndef USB_VENDOR_ID_RAZER
 #define USB_VENDOR_ID_RAZER 0x1532

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -22,6 +22,7 @@ let customMouseDockColor = null;
 let customMouseMatColor = null;
 let customEgpuColor = null;
 let customHeadphoneColor = null;
+let customAccessoryColor = null;
 let cycleColors = null;
 
 function isEmpty(obj) {
@@ -141,6 +142,22 @@ function loadItemsFromStorage() {
     }
   });
 
+  storage.get('customAccessoryColor', function (error, data) {
+    if (error) throw error;
+
+    customAccessoryColor = data;
+    if (isEmpty(customAccessoryColor)) {
+      customAccessoryColor = {
+        hex: '#ffff00',
+        rgb: {
+          r: 255,
+          g: 255,
+          b: 0,
+        },
+      };
+    }
+  });
+
   storage.get('cycleColors', function (error, data) {
     if (error) throw error;
 
@@ -224,6 +241,13 @@ function setDevicesCycleColors(colors) {
       colors[cycleColorsIndex].g,
       colors[cycleColorsIndex].b,
     ])
+  );
+  addon.accessorySetModeStaticNoStore(
+      new Uint8Array([
+        colors[cycleColorsIndex].r,
+        colors[cycleColorsIndex].g,
+        colors[cycleColorsIndex].b,
+      ])
   );
 
   cycleColorsIndex++;
@@ -1604,6 +1628,240 @@ let headphoneMenu = [
   },
 ];
 
+let accessoryMenu = [
+  { type: 'separator' },
+  {
+    label: 'No accessory found',
+    enabled: false,
+  },
+  { type: 'separator' },
+  {
+    label: 'None',
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.accessorySetModeNone();
+    },
+  },
+  {
+    label: 'Static',
+    submenu: [
+      {
+        label: 'Custom color',
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.accessorySetModeStatic(
+              new Uint8Array([
+                customAccessoryColor.rgb.r,
+                customAccessoryColor.rgb.g,
+                customAccessoryColor.rgb.b,
+              ])
+          );
+        },
+      },
+      {
+        label: 'White',
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.accessorySetModeStatic(new Uint8Array([0xff, 0xff, 0xff]));
+        },
+      },
+      {
+        label: 'Red',
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.accessorySetModeStatic(new Uint8Array([0xff, 0, 0]));
+        },
+      },
+      {
+        label: 'Green',
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.accessorySetModeStatic(new Uint8Array([0, 0xff, 0]));
+        },
+      },
+      {
+        label: 'Blue',
+        click() {
+          clearInterval(cycleColorsInterval);
+          addon.accessorySetModeStatic(new Uint8Array([0, 0, 0xff]));
+        },
+      },
+    ],
+  },
+  {
+    label: 'Wave',
+    submenu: [
+      {
+        label: 'Left',
+        submenu: [
+          {
+            label: 'Turtle Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_turtle');
+            },
+          },
+          {
+            label: 'Slowest Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_slowest');
+            },
+          },
+          {
+            label: 'Slower Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_slower');
+            },
+          },
+          {
+            label: 'Slow Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_slow');
+            },
+          },
+          {
+            label: 'Normal Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_default');
+            },
+          },
+          {
+            label: 'Fast Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_fast');
+            },
+          },
+          {
+            label: 'Faster Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_faster');
+            },
+          },
+          {
+            label: 'Fastest Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_fastest');
+            },
+          },
+          {
+            label: 'Lightning Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('left_lightning');
+            },
+          },
+        ],
+      },
+      {
+        label: 'Right',
+        submenu: [
+          {
+            label: 'Turtle Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_turtle');
+            },
+          },
+          {
+            label: 'Slowest Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_slowest');
+            },
+          },
+          {
+            label: 'Slower Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_slower');
+            },
+          },
+          {
+            label: 'Slow Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_slow');
+            },
+          },
+
+          {
+            label: 'Normal Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_default');
+            },
+          },
+          {
+            label: 'Fast Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_fast');
+            },
+          },
+          {
+            label: 'Faster Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_faster');
+            },
+          },
+          {
+            label: 'Fastest Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_fastest');
+            },
+          },
+          {
+            label: 'Lightning Speed',
+            click() {
+              clearInterval(cycleColorsInterval);
+              addon.accessorySetModeWave('right_lightning');
+            },
+          },
+
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Spectrum',
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.accessorySetModeSpectrum();
+    },
+  },
+  {
+    label: 'Breathe',
+    click() {
+      clearInterval(cycleColorsInterval);
+      addon.accessorySetModeBreathe(
+          new Uint8Array([
+            0, // random
+          ])
+      );
+    },
+  },
+  {
+    label: 'Set custom color',
+    click() {
+      window.webContents.send('device-selected', {
+        device: 'Accessory',
+        currentColor: customAccessoryColor,
+      });
+      window.setSize(500, 300);
+      window.show();
+    },
+  },
+];
+
 let mainMenuBottom = [
   { type: 'separator' },
   {
@@ -1630,6 +1888,7 @@ let mouseDockDeviceName = '';
 let mouseMatDeviceName = '';
 let egpuDeviceName = '';
 let headphoneDeviceName = '';
+let accessoryDeviceName = '';
 let mouseBatteryLevel = -1;
 let mouseCharging = false;
 
@@ -1641,6 +1900,7 @@ const refreshDevices = () => {
   addon.closeMouseMatDevice();
   addon.closeEgpuDevice();
   addon.closeHeadphoneDevice();
+  addon.closeAccessoryDevice();
 
   // get devices
   keyboardDeviceName = addon.getKeyboardDevice();
@@ -1652,6 +1912,7 @@ const refreshDevices = () => {
   mouseBatteryLevel = addon.getBatteryLevel();
   mouseCharging = addon.getChargingStatus();
   headphoneDeviceName = addon.getHeadphoneDevice();
+  accessoryDeviceName = addon.getAccessoryDevice();
 };
 
 app.on('ready', () => {
@@ -1670,6 +1931,7 @@ app.on('quit', () => {
   addon.closeMouseMatDevice();
   addon.closeEgpuDevice();
   addon.closeHeadphoneDevice();
+  addon.closeAccessoryDevice();
 });
 
 nativeTheme.on('updated', () => {
@@ -1722,6 +1984,10 @@ ipcMain.on('request-set-custom-color', (event, arg) => {
       case 'Headphone':
         customHeadphoneColor = color;
         storage.set('customHeadphoneColor', customHeadphoneColor);
+        break;
+      case 'Accessory':
+        customAccessoryColor = color;
+        storage.set('customAccessoryColor', customAccessoryColor);
         break;
       default:
     }
@@ -1856,6 +2122,10 @@ function refreshTray() {
   if (headphoneDeviceName) {
     headphoneMenu[1].label = headphoneDeviceName;
     menu = menu.concat(headphoneMenu);
+  }
+  if (accessoryDeviceName) {
+    accessoryMenu[1].label = accessoryDeviceName;
+    menu = menu.concat(accessoryMenu);
   }
   menu = menu.concat(mainMenuBottom);
 


### PR DESCRIPTION
This should add support for the following devices:
- RAZER_NOMMO_CHROMA
- RAZER_NOMMO_PRO
- RAZER_CHROMA_MUG
- RAZER_CHROMA_BASE
- RAZER_CHROMA_HDK
- RAZER_MOUSE_BUNGEE_V3_CHROMA
- RAZER_BASE_STATION_V2_CHROMA

Firefly / Goliath (mousemat), Core (egpu), Kraken Kitty (headphone) have been removed from this file as they are handled elsewhere.

Tested with own RAZER_BASE_STATION_V2_CHROMA