### PR TITLE
#253 - v0.3.6 doesn't support razer nommo pro. 

### DIFF
--- a/src/driver/razerdevice.c
+++ b/src/driver/razerdevice.c
@@ -199,6 +199,12 @@ bool is_accessory(IOUSBDeviceInterface **usb_dev)
 
     switch (product)
     {
+        case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+        case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+        case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+        case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+        case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+        case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
         case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
             return true;
     }


### PR DESCRIPTION
The accessory devices were implemented but not correctly detected yet. Flagged in #253.
This fix should properly detect the following devices now:
- RAZER_NOMMO_CHROMA
- RAZER_NOMMO_PRO
- RAZER_CHROMA_MUG
- RAZER_CHROMA_BASE
- RAZER_CHROMA_HDK
- RAZER_MOUSE_BUNGEE_V3_CHROMA