### PR TITLE
Ripple effect: Configure correctly or disable the feature

### DIFF
--- a/src/devices/anansi.json
+++ b/src/devices/anansi.json
@@ -3,5 +3,6 @@
   "productId": "0x010F",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/54/54_anansi.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/blackwidow_2019.json
+++ b/src/devices/blackwidow_2019.json
@@ -3,5 +3,11 @@
   "productId": "0x0241",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1501/1501-blackwidow2019.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_chroma.json
+++ b/src/devices/blackwidow_chroma.json
@@ -3,5 +3,11 @@
   "productId": "0x0203",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/279/279_blackwidow_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_chroma_te.json
+++ b/src/devices/blackwidow_chroma_te.json
@@ -3,5 +3,11 @@
   "productId": "0x0209",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/571/571_blackwidow_tournament_edition_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_chroma_v2.json
+++ b/src/devices/blackwidow_chroma_v2.json
@@ -3,5 +3,11 @@
   "productId": "0x0221",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1179/1179_blackwidow_chroma_v2_alt.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_elite.json
+++ b/src/devices/blackwidow_elite.json
@@ -3,5 +3,11 @@
   "productId": "0x0228",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1398/1398_blackwidowelite.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_essential.json
+++ b/src/devices/blackwidow_essential.json
@@ -3,5 +3,11 @@
   "productId": "0x0237",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1501/1501-blackwidow2019.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_lite.json
+++ b/src/devices/blackwidow_lite.json
@@ -3,5 +3,6 @@
   "productId": "0x0235",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1456/1456_blackwidowlite_-_2.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/blackwidow_overwatch.json
+++ b/src/devices/blackwidow_overwatch.json
@@ -3,5 +3,11 @@
   "productId": "0x0211",
   "mainType": "keyboard",
   "image": null,
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_stealth.json
+++ b/src/devices/blackwidow_stealth.json
@@ -3,5 +3,11 @@
   "productId": "0x011B",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-01.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_stealth_edition.json
+++ b/src/devices/blackwidow_stealth_edition.json
@@ -3,5 +3,11 @@
   "productId": "0x010E",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-01.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_ultimate_2012.json
+++ b/src/devices/blackwidow_ultimate_2012.json
@@ -3,5 +3,11 @@
   "productId": "0x010D",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/563/563_blackwidow_ultimate_classic.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_ultimate_2013.json
+++ b/src/devices/blackwidow_ultimate_2013.json
@@ -3,5 +3,11 @@
   "productId": "0x011A",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/245/438_blackwidow_ultimate_2014.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_ultimate_2016.json
+++ b/src/devices/blackwidow_ultimate_2016.json
@@ -3,5 +3,11 @@
   "productId": "0x0214",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/616/616_blackwidow_ultimate_2016.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_v3_tk.json
+++ b/src/devices/blackwidow_v3_tk.json
@@ -3,5 +3,11 @@
   "productId": "0x0a24",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1709/1709-blackwidow-v3-tkl.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 18
+    }
+  }]
 }

--- a/src/devices/blackwidow_x_chroma.json
+++ b/src/devices/blackwidow_x_chroma.json
@@ -3,5 +3,11 @@
   "productId": "0x0216",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/716/716_blackwidow_x_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_x_chroma_te.json
+++ b/src/devices/blackwidow_x_chroma_te.json
@@ -3,5 +3,11 @@
   "productId": "0x021A",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/717/717_blackwidow_x_tournament_edition_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blackwidow_x_ultimate.json
+++ b/src/devices/blackwidow_x_ultimate.json
@@ -3,5 +3,11 @@
   "productId": "0x0217",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/718/718_blackwidow_x_ultimate.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blade_2018.json
+++ b/src/devices/blade_2018.json
@@ -3,5 +3,11 @@
   "productId": "0x0233",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1418/1418_blade_2018__base.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_2018_base.json
+++ b/src/devices/blade_2018_base.json
@@ -3,5 +3,6 @@
   "productId": "0x023b",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1418/1418_blade_2018__base.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/blade_2018_mercury.json
+++ b/src/devices/blade_2018_mercury.json
@@ -3,5 +3,11 @@
   "productId": "0x0240",
   "mainType": "keyboard",
   "image": null,
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_2019_adv.json
+++ b/src/devices/blade_2019_adv.json
@@ -3,5 +3,11 @@
   "productId": "0x023a",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1482/blade15.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_2019_base.json
+++ b/src/devices/blade_2019_base.json
@@ -3,5 +3,6 @@
   "productId": "0x0246",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1518/1518_blade15_mid2019-base.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/blade_late_2016.json
+++ b/src/devices/blade_late_2016.json
@@ -3,5 +3,11 @@
   "productId": "0x0224",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_mid_2019_mercury.json
+++ b/src/devices/blade_mid_2019_mercury.json
@@ -3,5 +3,11 @@
   "productId": "0x0245",
   "mainType": "keyboard",
   "image": "https://assets2.razerzone.com/images/blade-15/shop/blade15-mercury-1.jpg",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_pro_2017.json
+++ b/src/devices/blade_pro_2017.json
@@ -3,5 +3,11 @@
   "productId": "0x0225",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1200/1200_blade_pro_2017.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 25
+    }
+  }]
 }

--- a/src/devices/blade_pro_2017_fullhd.json
+++ b/src/devices/blade_pro_2017_fullhd.json
@@ -3,5 +3,11 @@
   "productId": "0x022F",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1200/1200_blade_pro_2017.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 25
+    }
+  }]
 }

--- a/src/devices/blade_pro_late_2016.json
+++ b/src/devices/blade_pro_late_2016.json
@@ -3,5 +3,11 @@
   "productId": "0x0210",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blade_qhd.json
+++ b/src/devices/blade_qhd.json
@@ -3,5 +3,11 @@
   "productId": "0x020F",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_stealth.json
+++ b/src/devices/blade_stealth.json
@@ -3,5 +3,11 @@
   "productId": "0x0205",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/667/667_blade_stealth_2016_6500u.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/blade_stealth_2019.json
+++ b/src/devices/blade_stealth_2019.json
@@ -3,5 +3,6 @@
   "productId": "0x0239",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1475/1475_bladestealth13(2019).png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/blade_stealth_late_2016.json
+++ b/src/devices/blade_stealth_late_2016.json
@@ -3,5 +3,11 @@
   "productId": "0x0220",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/667/667_blade_stealth_2016_6500u.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_stealth_late_2017.json
+++ b/src/devices/blade_stealth_late_2017.json
@@ -3,5 +3,11 @@
   "productId": "0x0232",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1213/1213_blade_stealth_2017_7500u.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_stealth_late_2019.json
+++ b/src/devices/blade_stealth_late_2019.json
@@ -3,5 +3,6 @@
   "productId": "0x024a",
   "mainType": "keyboard",
   "image": "https://assets2.razerzone.com/images/blade-stealth-13/shop/stealth-l2p-1.jpg",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/blade_stealth_mid_2017.json
+++ b/src/devices/blade_stealth_mid_2017.json
@@ -3,5 +3,11 @@
   "productId": "0x022D",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1213/1213_blade_stealth_2017_7500u.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/blade_studio_edition_2019.json
+++ b/src/devices/blade_studio_edition_2019.json
@@ -3,5 +3,11 @@
   "productId": "0x024d",
   "mainType": "keyboard",
   "image": null,
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 16
+    }
+  }]
 }

--- a/src/devices/cynosa_chroma.json
+++ b/src/devices/cynosa_chroma.json
@@ -3,5 +3,11 @@
   "productId": "0x022A",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1256/1256_cynosa_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/cynosa_lite.json
+++ b/src/devices/cynosa_lite.json
@@ -3,5 +3,6 @@
   "productId": "0x023F",
   "mainType": "keyboard",
   "image": "https://assets2.razerzone.com/images/og-image/cynosa-lite-OGimage.jpg",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/cynosa_v2.json
+++ b/src/devices/cynosa_v2.json
@@ -3,5 +3,11 @@
   "productId": "0x025E",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1694/1694-2.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/deathstalker_chroma.json
+++ b/src/devices/deathstalker_chroma.json
@@ -3,5 +3,11 @@
   "productId": "0x0204",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/665/665_deathstalker_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 1,
+      "cols": 6
+    }
+  }]
 }

--- a/src/devices/deathstalker_expert.json
+++ b/src/devices/deathstalker_expert.json
@@ -3,5 +3,6 @@
   "productId": "0x0202",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/49/49_razer_deathstalker.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/huntsman.json
+++ b/src/devices/huntsman.json
@@ -3,5 +3,11 @@
   "productId": "0x0227",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1360/1360_huntsman-3.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/huntsman_elite.json
+++ b/src/devices/huntsman_elite.json
@@ -3,5 +3,11 @@
   "productId": "0x0226",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1361/1361_huntsman_elite.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 9,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/huntsman_mini.json
+++ b/src/devices/huntsman_mini.json
@@ -3,5 +3,11 @@
   "productId": "0x0257",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1689/1689-huntsmanmini.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 5,
+      "cols": 15
+    }
+  }]
 }

--- a/src/devices/huntsman_te.json
+++ b/src/devices/huntsman_te.json
@@ -3,5 +3,11 @@
   "productId": "0x0243",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1537/1537_huntsman_te.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 18
+    }
+  }]
 }

--- a/src/devices/nostromo.json
+++ b/src/devices/nostromo.json
@@ -3,5 +3,6 @@
   "productId": "0x0111",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/564/564_tartarus_classic.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/orbweaver.json
+++ b/src/devices/orbweaver.json
@@ -3,5 +3,6 @@
   "productId": "0x0113",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/56/56_orbweaver.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/orbweaver_chroma.json
+++ b/src/devices/orbweaver_chroma.json
@@ -3,5 +3,11 @@
   "productId": "0x0207",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/607/607_orbweaver_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 5,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/ornata.json
+++ b/src/devices/ornata.json
@@ -3,5 +3,11 @@
   "productId": "0x021F",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/726/726_ornata.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/ornata_chroma.json
+++ b/src/devices/ornata_chroma.json
@@ -3,5 +3,11 @@
   "productId": "0x021E",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/727/727_ornata_chroma.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/ornata_v2.json
+++ b/src/devices/ornata_v2.json
@@ -3,5 +3,11 @@
   "productId": "0x025D",
   "mainType": "keyboard",
   "image": null,
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 6,
+      "cols": 22
+    }
+  }]
 }

--- a/src/devices/tartarus.json
+++ b/src/devices/tartarus.json
@@ -3,5 +3,6 @@
   "productId": "0x0201",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/228/228_tartarus.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/tartarus_chroma.json
+++ b/src/devices/tartarus_chroma.json
@@ -3,5 +3,6 @@
   "productId": "0x0208",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/598/598_tartarus_chroma.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["ripple"]
 }

--- a/src/devices/tartarus_v2.json
+++ b/src/devices/tartarus_v2.json
@@ -3,5 +3,11 @@
   "productId": "0x022B",
   "mainType": "keyboard",
   "image": "https://assets.razerzone.com/eeimages/support/products/1255/1255_tartarus_v2.png",
-  "features": null
+  "features": null,
+  "featuresConfig": [{
+    "ripple": {
+      "rows": 4,
+      "cols": 6
+    }
+  }]
 }

--- a/src/main/animation/animationripple.js
+++ b/src/main/animation/animationripple.js
@@ -2,7 +2,7 @@ import { RazerDeviceAnimation } from './animation';
 
 export class RazerAnimationRipple extends RazerDeviceAnimation {
 
-  constructor(device, color, backgroundColor = [0, 0, 0]) {
+  constructor(device, featureConfiguration, color, backgroundColor = [0, 0, 0]) {
     super();
     this.KEY_MAPPING = {
       1: [0, 1],
@@ -118,24 +118,25 @@ export class RazerAnimationRipple extends RazerDeviceAnimation {
 
     this.device = device;
     this.ioHook = require('iohook');
+
+    this.nRows = featureConfiguration.rows;
+    this.nCols = featureConfiguration.cols;
   }
 
   start() {
     this.ioHook.start();
 
-    const nRows = 6;
-    const nCols = 22;
     const refreshRate = 0.05; // in seconds
     const eventDuration = 1; // in seconds
     const speed = 20; // number of keys per second
     const width = 2; // number of keys
 
     // initialization
-    let matrix = Array(nRows)
+    let matrix = Array(this.nRows)
       .fill()
-      .map(() => Array(nCols).fill(this.backgroundColor));
-    for (let i = 0; i < nRows; i++) {
-      let row = [i, 0, nCols - 1, ...matrix[i].flat()];
+      .map(() => Array(this.nCols).fill(this.backgroundColor));
+    for (let i = 0; i < this.nRows; i++) {
+      let row = [i, 0, this.nCols - 1, ...matrix[i].flat()];
       this.device.setCustomFrame(new Uint8Array(row))
     }
     this.device.setModeCustom();
@@ -158,13 +159,13 @@ export class RazerAnimationRipple extends RazerDeviceAnimation {
       keyEvents = keyEvents.filter((event) => event.startTime + eventDuration > Date.now() / 1000);
 
       // clear keyboard
-      matrix = Array(nRows)
+      matrix = Array(this.nRows)
         .fill()
-        .map(() => Array(nCols).fill(this.backgroundColor));
+        .map(() => Array(this.nCols).fill(this.backgroundColor));
 
       // set color
-      for (let i = 0; i < nRows; i++) {
-        for (let j = 0; j < nCols; j++) {
+      for (let i = 0; i < this.nRows; i++) {
+        for (let j = 0; j < this.nCols; j++) {
           for (let event of keyEvents) {
             const radius = (Date.now() / 1000 - event.startTime) * speed;
             const distance = Math.sqrt(
@@ -179,8 +180,8 @@ export class RazerAnimationRipple extends RazerDeviceAnimation {
       }
 
       // set ripple effect
-      for (let i = 0; i < nRows; i++) {
-        let row = [i, 0, nCols - 1, ...matrix[i].flat()];
+      for (let i = 0; i < this.nRows; i++) {
+        let row = [i, 0, this.nCols - 1, ...matrix[i].flat()];
         this.device.setCustomFrame(new Uint8Array(row));
       }
       this.device.setModeCustom();

--- a/src/main/device/razerdevicekeyboard.js
+++ b/src/main/device/razerdevicekeyboard.js
@@ -84,9 +84,9 @@ export class RazerDeviceKeyboard extends RazerDevice {
     }
   }
 
-  setRippleEffect(color, backgroundColor) {
+  setRippleEffect(featureConfiguration, color, backgroundColor) {
     this.stopAnimations();
-    this.rippleAnimation = new RazerAnimationRipple(this, color, backgroundColor);
+    this.rippleAnimation = new RazerAnimationRipple(this, featureConfiguration, color, backgroundColor);
     this.rippleAnimation.start();
   }
 

--- a/src/main/feature/featureripple.js
+++ b/src/main/feature/featureripple.js
@@ -5,4 +5,11 @@ export class FeatureRipple extends Feature {
   constructor(config) {
     super(FeatureHelper.FEATURE_RIPPLE, config);
   }
+
+  getDefaultConfiguration() {
+    return {
+      rows: -1,
+      cols: -1,
+    }
+  }
 }

--- a/src/main/menu/menubuilderdevice.js
+++ b/src/main/menu/menubuilderdevice.js
@@ -192,11 +192,19 @@ function getFeatureReactive(application, device, feature) {
 }
 
 function getFeatureRipple(application, device, feature) {
+
+  if(feature.configuration == null || feature.configuration.rows === -1 ||  feature.configuration.cols === -1) {
+    return {
+      label: 'Ripple (missing rows, cols config)',
+      enabled: false
+    };
+  }
+
   const singleItem = (label, color, backgroundColor) => {
     return {
       label: label,
       click() {
-        device.setRippleEffect(color, backgroundColor);
+        device.setRippleEffect(feature.configuration, color, backgroundColor);
       },
     };
   };


### PR DESCRIPTION
Different keyboard types have different rows / cols to set custom frame keys.

This could help improve (maybe even fix) #307 and #304