### PR TITLE
add support for naga pro

### DIFF
--- a/src/devices/naga_pro_wired.json
+++ b/src/devices/naga_pro_wired.json
@@ -1,0 +1,23 @@
+{
+  "name": "Razer Naga Pro - Wired",
+  "productId": "0x008f",
+  "mainType": "mouse",
+  "image": "https://assets.razerzone.com/eeimages/support/products/1710/small_product.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects"],
+  "featuresConfig": [
+    {
+      "mouseBrightness": {
+        "enabledLogo": false,
+        "enabledScroll": false,
+        "enabledLeft": false,
+        "enabledRight": false
+      }
+    },
+    {
+      "dpi": {
+        "max": 20000
+      }
+    }
+  ]
+}

--- a/src/devices/naga_pro_wireless.json
+++ b/src/devices/naga_pro_wireless.json
@@ -1,0 +1,23 @@
+{
+  "name": "Razer Naga Pro - Wireless",
+  "productId": "0x0090",
+  "mainType": "mouse",
+  "image": "https://assets.razerzone.com/eeimages/support/products/1710/small_product.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects"],
+  "featuresConfig": [
+    {
+      "mouseBrightness": {
+        "enabledLogo": false,
+        "enabledScroll": false,
+        "enabledLeft": false,
+        "enabledRight": false
+      }
+    },
+    {
+      "dpi": {
+        "max": 20000
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for both wired and wireless (2.4GHz dongle) Naga Pro mouse

needs `librazermacos` PR to be merged first before this works.