### PR TITLE
iohook arm64 fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "librazermacos"]
 	path = librazermacos
 	url = https://github.com/1kc/librazermacos.git
+[submodule "iohook"]
+	path = iohook
+	url = git@github.com:sgulls/iohook.git

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "dot-prop": "^5.3.0",
     "electron-json-storage": "^4.2.0",
-    "iohook": "^0.9.3",
+    "iohook": "file:./iohook",
     "node-addon-api": "^1.0.0",
     "node-forge": "^0.10.0",
     "react": "^16.13.1",


### PR DESCRIPTION
ARM64 now builds and runs natively by adding prebuilt iohook binaries from my fork.