### PR TITLE
Attempt to fix cross compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Ongoing new device support will be provided on a volunteer contribution basis, a
 
 Ensure xcode command line tools are installed,
 
+If you have a paid Apple Developer account, edit `release.sh` with your details.
+
+ Afterwards, to automatically build, sign, and/or notarize (if applicable,) run `./release`.
+
+ Ad-hoc signing will be used if account information is left empty.
+
+
+
+ Or build manually:
+
 Install node package dependencies:
 
     yarn
@@ -122,6 +132,12 @@ During development, every time the driver code has been updated, a rebuild is re
 For building a distribution ready app and dmg:
 
     yarn dist
+
+Sign both packages before moving to /Applications folder with ad-hoc signing:
+
+    codesign -s - --deep --force ./dist/mac/Razer\ macOS.app
+    
+    codesign -s - --deep --force ./dist/mac-arm64/Razer\ macOS.app
 
 ## Implementation
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,13 +17,19 @@
           '-framework CoreFoundation'
       ],
       'xcode_settings': {
-          'VALID_ARCHS': 'arm64e x86_64',
+          'VALID_ARCHS': 'arm64 x86_64',
           'ONLY_ACTIVE_ARCH': 'NO',
           'OTHER_CODE_SIGN_FLAGS': 'timestamp --options=runtime',
           'CLANG_CXX_LIBRARY': 'libc++',
           'MACOSX_DEPLOYMENT_TARGET': '11.0',
           'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+          'OTHER_CFLAGS': [
+              '-arch x86_64',
+              '-arch arm64'
+          ],
           'OTHER_LDFLAGS': [
+              '-arch x86_64',
+              '-arch arm64',
               '-framework IOKit',
               '-framework CoreFoundation'
           ],

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-loader": "^8.1.0",
     "electron": "^11.2.2",
     "electron-builder": "^22.11.11",
+    "electron-builder-notarize": "^1.2.0",
     "electron-webpack": "^2.8.2",
     "mini-css-extract-plugin": "^0.9.0",
     "native-ext-loader": "^2.3.0",
@@ -68,6 +69,7 @@
       "output": "dist",
       "buildResources": "resources"
     },
+    "afterSign": "electron-builder-notarize",
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "icon.icns",

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export APPLE_ID=""
+export APPLE_ID_PASSWORD=""
+
+yarn clean
+rm -rf ./node_modules ./dist
+
+yarn
+
+yarn dist
+
+if [[ -z $APPLE_ID ]]
+then
+  codesign -s - --deep --force ./dist/mac/Razer\ macOS.app
+  codesign -s - --deep --force ./dist/mac-arm64/Razer\ macOS.app
+fi
+
+unset APPLE_ID
+unset APPLE_ID_PASSWORD


### PR DESCRIPTION
I tried fixing the cross-compilation issue and test packages are here: https://github.com/overcurrent/razer-macos/releases/tag/v0.4.5-fix-cross-compilation

I tried the Intel version using Rosetta translation layer and it runs for me now. It would result in a Javascript error related to 'addon.node' before until changes were made to the binding.gyp file.

Let me know if the Intel package also runs natively. If not, need to revert this change and think of something else.

Also, a build script to help notarize the packages was added. 