### PR TITLE
Add missing features for Razer Deathadder Chroma

### DIFF
--- a/src/devices/deathadder_chroma.json
+++ b/src/devices/deathadder_chroma.json
@@ -17,5 +17,6 @@
         "max": 10000
       }
     }
-  ]
+  ],
+  "featuresMissing": ["none","waveSimple", "spectrum", "reactive", "breathe"]
 }


### PR DESCRIPTION
This will hide all the effects that are not supported on this mouse.