### PR TITLE
Making v0.4.7 out of current master and providing signed build image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Open source color effects manager for Razer peripherals on macOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",


### PR DESCRIPTION
Create version v0.4.7 from master as code signature was missing from 0.4.6 and also following items were added after 0.4.6:
- Razer Deathadder Chroma fixes/missing features
- Thunderbolt 4 Dock Chroma support

Get signed universal image here: https://github.com/overcurrent/razer-macos/releases/download/v0.4.7/Razer.macOS-0.4.7-universal.dmg

Tested on Monterey 12.0.1 in both native M1 and Rosetta modes.
Ripple effects tested with Razer Huntsman.