### PR TITLE
Mamba Wireless Parity Improvement

### DIFF
--- a/src/devices/mamba_wireless.json
+++ b/src/devices/mamba_wireless.json
@@ -4,8 +4,14 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png",
   "features": null,
-  "featuresMissing": ["mouseBrightness"],
   "featuresConfig": [
+    {
+      "mouseBrightness": {
+        "enabledMatrix": false,
+        "enabledLeft": false,
+        "enabledRight": false
+      }
+    },
     {
       "dpi": {
         "max": 16000

--- a/src/devices/mamba_wireless_wired.json
+++ b/src/devices/mamba_wireless_wired.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png",
   "features": null,
+  "featuresMissing": ["mouseBrightness"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/mamba_wireless_wired.json
+++ b/src/devices/mamba_wireless_wired.json
@@ -4,7 +4,6 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png",
   "features": null,
-  "featuresMissing": ["mouseBrightness"],
   "featuresConfig": [
     {
       "mouseBrightness": {


### PR DESCRIPTION
@1kc & @overcurrent, this is another frontend cleanup PR. Be sure to include it in the next release. One more is coming later today. It's a lot bigger, so it can wait for v0.4.9, if needed.

PR Details: 
- mamba_wireless.json listed `mouseBrightness` as a missing feature
- mamba_wireless_wired.json & mamba_wireless_reciever.json didn't have any `featuresMissing` args
- openrazer shows it supports that feature regardless of connection
- openrazer shows `mamba_wireless.json` was missing `mouseBrightness` args in `featuresConfig`