### PR TITLE
Add 'featuresMissing' to Frontend (mice only)

### DIFF
--- a/src/devices/abyssus_elite_dva_edition.json
+++ b/src/devices/abyssus_elite_dva_edition.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1288/d.va_abyssus_elite.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/abyssus_essential.json
+++ b/src/devices/abyssus_essential.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1290/1290_abyssusessential.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/basilisk.json
+++ b/src/devices/basilisk.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1241/1241_basilisk.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "dpi": {

--- a/src/devices/basilisk_v2.json
+++ b/src/devices/basilisk_v2.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1617/1617_basilisk-v2.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "dpi": {

--- a/src/devices/deathadder_3500.json
+++ b/src/devices/deathadder_3500.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/561/561_deathadder_classic.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/deathadder_chroma.json
+++ b/src/devices/deathadder_chroma.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/278/278_deathadder_chroma.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/deathadder_elite.json
+++ b/src/devices/deathadder_elite.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/724/724_deathadderelite_500x500.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/deathadder_essential.json
+++ b/src/devices/deathadder_essential.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1385/1385_deathadderessential.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/deathadder_essential_white_edition.json
+++ b/src/devices/deathadder_essential_white_edition.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-25.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/deathadder_v2.json
+++ b/src/devices/deathadder_v2.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1612/1612_razerdeathadderv2.png",
   "features": null,
+  "featuresMissing": ["waveSimple","oldMouseEffects"],
   "featuresConfig": [
     {
       "dpi": {

--- a/src/devices/deathadder_v2_mini.json
+++ b/src/devices/deathadder_v2_mini.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1692/deathadder-v2-mini.png",
   "features": null,
+  "featuresMissing": ["waveSimple","oldMouseEffects"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/deathadder_v2_pro_wired.json
+++ b/src/devices/deathadder_v2_pro_wired.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1714/comp_1_00000.png",
   "features": null,
+  "featuresMissing": ["waveSimple","oldMouseEffects"],
   "featuresConfig": [
     {
       "dpi": {

--- a/src/devices/deathadder_v2_pro_wireless.json
+++ b/src/devices/deathadder_v2_pro_wireless.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1714/comp_1_00000.png",
   "features": null,
+  "featuresMissing": ["waveSimple","oldMouseEffects"],
   "featuresConfig": [
     {
       "dpi": {

--- a/src/devices/mamba_2012_wired.json
+++ b/src/devices/mamba_2012_wired.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/192/192_mamba_2012.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/mamba_2012_wireless.json
+++ b/src/devices/mamba_2012_wireless.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/192/192_mamba_2012.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/mamba_wireless.json
+++ b/src/devices/mamba_wireless.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/mamba_wireless_receiver.json
+++ b/src/devices/mamba_wireless_receiver.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/mamba_wireless_wired.json
+++ b/src/devices/mamba_wireless_wired.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/naga_chroma.json
+++ b/src/devices/naga_chroma.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/636/636_naga_chroma.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/naga_hex_v2.json
+++ b/src/devices/naga_hex_v2.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/715/715_nagahexv2_500x500.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/naga_pro_wired.json
+++ b/src/devices/naga_pro_wired.json
@@ -4,7 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1710/small_product.png",
   "features": null,
-  "featuresMissing": ["oldMouseEffects"],
+  "featuresMissing": ["oldMouseEffects","waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/naga_pro_wireless.json
+++ b/src/devices/naga_pro_wireless.json
@@ -4,7 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1710/small_product.png",
   "features": null,
-  "featuresMissing": ["oldMouseEffects"],
+  "featuresMissing": ["oldMouseEffects","waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/naga_trinity.json
+++ b/src/devices/naga_trinity.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1251/1251_razer_naga_trinity.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/ouroboros.json
+++ b/src/devices/ouroboros.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/26/26_ouroboros.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/viper.json
+++ b/src/devices/viper.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1539/1539_viper.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/viper_8khz.json
+++ b/src/devices/viper_8khz.json
@@ -3,5 +3,21 @@
   "productId": "0x0091",
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1755/viper8khz.png",
-  "features": null
+  "features": null,
+  "featuresMissing": ["waveSimple"],
+  "featuresConfig": [
+    {
+      "mouseBrightness": {
+        "enabledMatrix": false,
+        "enabledScroll": false,
+        "enabledLeft": false,
+        "enabledRight": false
+      }
+    },
+    {
+      "dpi": {
+        "max": 20000
+      }
+    }
+  ]
 }

--- a/src/devices/viper_ultimate_wired.json
+++ b/src/devices/viper_ultimate_wired.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1577/ee_photo.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {

--- a/src/devices/viper_ultimate_wireless.json
+++ b/src/devices/viper_ultimate_wireless.json
@@ -4,6 +4,7 @@
   "mainType": "mouse",
   "image": "https://assets.razerzone.com/eeimages/support/products/1577/ee_photo.png",
   "features": null,
+  "featuresMissing": ["waveSimple"],
   "featuresConfig": [
     {
       "mouseBrightness": {


### PR DESCRIPTION
- Many mice had features missing, but weren't listed
- Added `featuresConfig` & `featuresMissing` to Viper 8KHz

Notes:
1. I did not check any that already had `featuresMissing` except one
2. I only checked `oldMouseEffects` support for the DeathAdder Elite & newer DeathAdder Mice
3. While I did not check for any missing features beyond those, it shouldn't be needed as the rest should support all devices.