### PR TITLE
Add support for Huntsman v2 TKL

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Keyboards:
 - Razer Huntsman Mini
 - Razer Huntsman Tournament Edition
 - Razer Huntsman V2
+- Razer Huntsman v2 TKL
 - Razer Huntsman V2 Analog
 - Razer Nostromo
 - Razer Orbweaver

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Keyboards:
 - Razer Huntsman Mini
 - Razer Huntsman Tournament Edition
 - Razer Huntsman V2
-- Razer Huntsman v2 TKL
+- Razer Huntsman V2 TKL
 - Razer Huntsman V2 Analog
 - Razer Nostromo
 - Razer Orbweaver

--- a/src/devices/huntsman_v2_tkl.json
+++ b/src/devices/huntsman_v2_tkl.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Huntsman V2 TKL",
+  "productId": "0x026b",
+  "mainType": "keyboard",
+  "image": "https://assets3.razerzone.com/02qciF5cWDrRcrL9CxzbHC017No=/500x500/https%3A%2F%2Fhybrismediaprod.blob.core.windows.net%2Fsys-master-phoenix-images-container%2Fhb8%2Fhd7%2F9239675600926%2Fhuntsman-v2-tkl-500x500.png",
+  "features": null,
+  "featuresConfig": [
+    {
+      "ripple": {
+          "rows": 6,
+          "cols": 22
+      }
+    },
+    {
+      "wheel": {
+          "rows": 6,
+          "cols": 22
+      }
+    }
+  ]
+}

--- a/src/devices/huntsman_v2_tkl.json
+++ b/src/devices/huntsman_v2_tkl.json
@@ -2,7 +2,7 @@
   "name": "Razer Huntsman V2 TKL",
   "productId": "0x026b",
   "mainType": "keyboard",
-  "image": "https://assets3.razerzone.com/02qciF5cWDrRcrL9CxzbHC017No=/500x500/https%3A%2F%2Fhybrismediaprod.blob.core.windows.net%2Fsys-master-phoenix-images-container%2Fhb8%2Fhd7%2F9239675600926%2Fhuntsman-v2-tkl-500x500.png",
+  "image": "https://dl.razerzone.com/src/5638/5638-1-en-v1.png",
   "features": null,
   "featuresConfig": [
     {

--- a/src/devices/huntsman_v2_tkl.json
+++ b/src/devices/huntsman_v2_tkl.json
@@ -8,13 +8,13 @@
     {
       "ripple": {
           "rows": 6,
-          "cols": 22
+          "cols": 18
       }
     },
     {
       "wheel": {
           "rows": 6,
-          "cols": 22
+          "cols": 18
       }
     }
   ]


### PR DESCRIPTION
Hi, I've added support for the Razer Huntsman v2 TKL in librazermacos, and I've noticed it's missing here as well.

Since the device is basically the same as the regular Huntsman v2 TKL, I've added support for it based on the features that device had.

I've tested the changes with a custom build -  the keyboard is detected properly, and all light effects seem to work just fine.

Thank you for all of your work on this program.