### PR TITLE
Fix Complier for macOS 12.3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
     "react-select": "^3.2.0",
     "react-slider": "^1.1.2",
     "react-tabs": "^3.1.2",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "tinycolor2": "^1.4.2"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.9.4",
     "babel-loader": "^8.1.0",
     "electron": "^11.5.0",
-    "electron-builder": "^23.0.3",
+    "electron-builder": "^23.3.3",
     "electron-builder-notarize": "^1.2.0",
     "electron-webpack": "^2.8.2",
     "@electron/universal": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
     "react-select": "^3.2.0",
     "react-slider": "^1.1.2",
     "react-tabs": "^3.1.2",
-    "source-map-support": "^0.5.12",
+    "source-map-support": "^0.5.16",
     "tinycolor2": "^1.4.2"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.9.4",
     "babel-loader": "^8.1.0",
     "electron": "^11.5.0",
-    "electron-builder": "^22.11.11",
+    "electron-builder": "^23.0.3",
     "electron-builder-notarize": "^1.2.0",
     "electron-webpack": "^2.8.2",
-    "@electron/universal": "^1.0.5",
+    "@electron/universal": "^1.2.1",
     "mini-css-extract-plugin": "^0.9.0",
     "native-ext-loader": "^2.3.0",
     "node-gyp": "^8.2.0",
@@ -60,12 +60,6 @@
     "appId": "com.electron.razer-macos",
     "productName": "Razer macOS",
     "nodeGypRebuild": true,
-    "asar": true,
-    "files": [
-      "package.json",
-      "build",
-      "node_modules"
-    ],
     "directories": {
       "output": "dist",
       "buildResources": "resources"


### PR DESCRIPTION
- Fixes #558 using minimal changes
- Dedupes source-map-support (both v0.5.16 or v0.5.19 work, so I chose the former to minimize the change)
- Removes `"asar": true` as the default is true
- Reduces universal app size thanks to the `mergesASARs` API in electron-universal and electron-builder

Explanation:
- The `mergeASARs` API was introduced in electron-universal v1.2.0 and electron-builder implemented it in v23.0.0 along with the fix for the removal of Python 2.7. This feature caused compiling to fail with `Can't reconcile two non-macho files`. 
- After speaking to the creator of the `mergeASARs` API and reviewing various documentations, I discovered that `build` in `"files": ...` overrode the default ignores for any files within it. Those files are unmergable.
- According to the electron-builder documentation:
> Default pattern `**/*` **is not added to your custom** if some of your patterns is not ignore (i.e. not starts with `!`). `package.json` and `**/node_modules/**/*` (only production dependencies will be copied) is added to your custom in any case. All default ignores are added in any case — you don’t need to repeat it if you configure own patterns.

- Since the default includes all needed files, simply removing `"files": ...` fixes the error and prevents future ones.