### PR TITLE
Added Tartarus Pro Support

### DIFF
--- a/src/devices/tartarus_pro.json
+++ b/src/devices/tartarus_pro.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Tartarus Pro",
+  "productId": "0x244",
+  "mainType": "keyboard",
+  "image": "https://assets.razerzone.com/eeimages/support/products/1255/1255_tartarus_v2.png",
+  "features": null,
+  "featuresConfig": [
+    {
+      "ripple": {
+          "rows": 4,
+          "cols": 6
+      }
+    },
+    {
+      "wheel": {
+          "rows": 4,
+          "cols": 6
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Uses the existing v2 image as they are visually identical but use different switches and a slightly different hand rest.