### PR TITLE
added Strider Chroma support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Mouse mats:
 - Razer Firefly V2
 - Razer Goliathus Chroma
 - Razer Goliathus Chroma Extended
+- Razer Strider Chroma
 
 e-GPUs:
 

--- a/src/devices/strider_chroma.json
+++ b/src/devices/strider_chroma.json
@@ -1,0 +1,7 @@
+{
+  "name": "Razer Strider Chroma",
+  "productId": "0x0c05",
+  "mainType": "mousemat",
+  "image": "https://assets.razerzone.com/eeimages/support/products/1594/1594_firefly_v2.png",
+  "features": null
+}


### PR DESCRIPTION
Tried to add support for Strider chroma - it seems to work the same way as the firefly v2 so I used that implementation for guidance. Haven't tested everything yet but it hasn't exploded so far and is currently lit up in static white (as set) so that's good. 
**IMPORTANT** (kinda)
I didn't know where to get the image for the device for the json config so the images currently set to one of the firefly v2. Should probably be changed before merging :)