### PR TITLE
Added support for Razer Laptop Stand Chroma

### DIFF
--- a/src/devices/laptop_stand_chroma.json
+++ b/src/devices/laptop_stand_chroma.json
@@ -1,0 +1,7 @@
+{
+  "name": "Razer Laptop Stand Chroma",
+  "productId": "0x0F2B",
+  "mainType": "accessory",
+  "image": "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container/hfe/hbc/9081459376158/Razer-Laptop-Stand-Chroma-04.jpg",
+  "features": null
+}


### PR DESCRIPTION
### Motivation

Added support for the Razer Laptop Stand. Almost all the Razer Devices on my desk were supported other than this one so I decided to add it myself.

### Librazermacos PR

https://github.com/1kc/librazermacos/pull/46

### Testing
Built via the ./release.sh script and tested using the Razer macOS app. The Laptop stand became present in the Apps menu and each item under the Laptop Dock was tested to make sure the correct result. Also tested to make sure the options under all devices also worked.

<img width="379" alt="Screenshot 2023-03-21 at 12 27 29" src="https://user-images.githubusercontent.com/29251905/226612191-e8e8921d-979f-4efe-a28c-cee65964a646.png">

<img width="612" alt="image" src="https://user-images.githubusercontent.com/29251905/226612363-ab240d81-9073-4fe3-9d97-efad49581cc2.png">

### Notes
According to OpenRazer the device should report as 0x0F0D but MacOS reports the device ID as 0x0F2B

### References
https://github.com/openrazer/openrazer/tree/master/driver/razeraccessory_driver.h
https://github.com/openrazer/openrazer/tree/master/driver/razeraccessory_driver.c