### PR TITLE
Basilisk V3 Pro (Wired & Wireless) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Mice:
 - Razer Basilisk Ultimate
 - Razer Basilisk V2
 - Razer Basilisk V3
+- Razer Basilisk V3 Pro (wired and wireless)
 - Razer DeathAdder 3 5G
 - Razer DeathAdder 1800
 - Razer DeathAdder 2013 (under older mouse effects)

--- a/src/devices/basilisk_v3_pro_wired.json
+++ b/src/devices/basilisk_v3_pro_wired.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Basilisk V3 Pro (Wired)",
+  "productId": "0x00AA",
+  "mainType": "mouse",
+  "image": "https://dl.razerzone.com/src2/6220/6220-4-en-v1.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "dpi": {
+        "max": 30000
+      }
+    },
+    {
+      "mouseBrightness": {
+        "enabledLeft": true,
+        "enabledRight": false
+      }
+    }
+  ]
+}

--- a/src/devices/basilisk_v3_pro_wireless.json
+++ b/src/devices/basilisk_v3_pro_wireless.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Basilisk V3 Pro (Wireless)",
+  "productId": "0x00AB",
+  "mainType": "mouse",
+  "image": "https://dl.razerzone.com/src2/6220/6220-4-en-v1.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "dpi": {
+        "max": 30000
+      }
+    },
+    {
+      "mouseBrightness": {
+        "enabledLeft": true,
+        "enabledRight": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Basilisk V3 Pro (Wired ⚡️ & Wireless 🛰️) support

This change includes support for both wired and wireless Basilisk V3 Pro mouse 🐁. 

### Tested for: 
* Editing scroll static, wave, and spectrum lights 🌈.
* Editing logo static, wave, and spectrum lights 🌈.
* Editing side static, wave, and spectrum lights 🌈.
* Editing DPI 🏃🏻‍♀️ 
* Show battery level (when plugged only) ⚡️.

Thank you to 1kc for macOS gamers world a better place 🕹️

#### Note
Follow the library submodule PR [here](https://github.com/1kc/librazermacos/pull/49).