### PR TITLE
Add support for Razer Basilisk V3 Pro 35K

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Mice:
 - Razer Basilisk Ultimate
 - Razer Basilisk V2
 - Razer Basilisk V3
+- Razer Basilisk V3 Pro 35K (wired and wireless)
 - Razer DeathAdder 3 5G
 - Razer DeathAdder 1800
 - Razer DeathAdder 2013 (under older mouse effects)

--- a/src/devices/basilisk_v3_pro_35k_wired.json
+++ b/src/devices/basilisk_v3_pro_35k_wired.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Basilisk V3 Pro 35K (Wired)",
+  "productId": "0x00CC",
+  "mainType": "mouse",
+  "image": "https://dl.razerzone.com/src2/6220/6220-4-en-v1.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "dpi": {
+        "max": 35000
+      }
+    },
+    {
+      "mouseBrightness": {
+        "enabledLeft": true,
+        "enabledRight": false
+      }
+    }
+  ]
+}

--- a/src/devices/basilisk_v3_pro_35k_wireless.json
+++ b/src/devices/basilisk_v3_pro_35k_wireless.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Basilisk V3 Pro 35K (Wireless)",
+  "productId": "0x00CD",
+  "mainType": "mouse",
+  "image": "https://dl.razerzone.com/src2/6220/6220-4-en-v1.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "dpi": {
+        "max": 35000
+      }
+    },
+    {
+      "mouseBrightness": {
+        "enabledLeft": true,
+        "enabledRight": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Battery status works on both wired and wireless!

![Screenshot 2025-04-18 at 3 29 25 PM](https://github.com/user-attachments/assets/335015bf-e207-43ef-9db4-8cbe519ffa42)

Since the project is dead, you can find precompiled `dmg` binary [here](https://github.com/DervexDev/razer-macos/releases/download/basilisk-v3-pro-35k/Razer.macOS-0.4.10-universal.dmg)